### PR TITLE
LPS-56209 First character of new line is included in hyperlink in ckeditor's bbcode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 CKEditor 4 Changelog
 ====================
+## CKEditor 4.0.3-r16
+* [#11947](http://dev.ckeditor.com/ticket/11947): [FF IE11] Shift+Enter in lists produces two line breaks.
+
 ## CKEditor 4.0.3-r15
 
 * [LPS-39430](https://issues.liferay.com/browse/LPS-39430): Provide config option to prevent indents on non-list content.

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -70,7 +70,7 @@ else
 fi
 
 CKEDITOR_VERSION="4.0.3"
-CKEDITOR_REVISION="15"
+CKEDITOR_REVISION="16"
 
 java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release --version $CKEDITOR_VERSION --revision $CKEDITOR_REVISION --build-config build-config.js --overwrite --no-tar --no-zip $DEV_OPS
 

--- a/plugins/enterkey/plugin.js
+++ b/plugins/enterkey/plugin.js
@@ -282,8 +282,11 @@
 					doc.createText( '\ufeff' ).insertAfter( lineBreak );
 
 					// If we are at the end of a block, we must be sure the bogus node is available in that block.
-					if ( isEndOfBlock )
-						lineBreak.getParent().appendBogus();
+					if ( isEndOfBlock ) {
+						// In most situations we've got an elementPath.block (e.g. <p>), but in a
+						// blockless editor or when autoP is false that needs to be a block limit.
+						( startBlock || elementPath.blockLimit ).appendBogus();
+					}
 
 					// Now we can remove the text node contents, so the caret doesn't
 					// stop on it.


### PR DESCRIPTION
Hey @blzaugg 

Can you see this pr?

This is a backport from ee-4.4.x: https://github.com/ckeditor/ckeditor-dev/commit/72090f5247f1b3549039b0eed576f3ef92f4c434.

Please help review

Many thanks
John.