### PR TITLE
chore: apply shellcheck fixes to ck.sh

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -45,7 +45,7 @@ case "$COMMAND" in
 		echo
 
 		echo "This will generate a patched version of CKEditor"
-		read -p "Are you sure you want to continue?[y/n] " yn
+		read -r -p "Are you sure you want to continue?[y/n] " yn
 
 		case $yn in
 			[Yy]*)
@@ -112,7 +112,7 @@ case "$COMMAND" in
 		cd ..
 
 		# Save SHA1 for later
-		sha1=`git submodule | grep ckeditor-dev | awk '{print $1}' | sed -e s/[^0-9a-f]//`
+		sha1=$(git submodule | grep ckeditor-dev | awk '{print $1}' | sed -e s/[^0-9a-f]//)
 
 		cd ckeditor-dev
 
@@ -145,7 +145,7 @@ case "$COMMAND" in
 			echo
 
 			# Prompt the user to confirm he wants to delete existing patches
-			read -p "Are you sure you want to continue?[y/n] " yn
+			read -r -p "Are you sure you want to continue?[y/n] " yn
 			case $yn in
 				[Yy]*)
 					echo
@@ -166,7 +166,7 @@ case "$COMMAND" in
 		echo "Generating patches."
 		echo
 
-		git format-patch $sha1 -o ../patches
+		git format-patch "$sha1" -o ../patches
 
 		echo
 		echo "✅  DONE"
@@ -185,7 +185,7 @@ case "$COMMAND" in
 		echo "❗  This will reset any changes you currently have in the 'ckeditor-dev' submodule"
 		echo
 		echo
-		read -p "Are you sure you want to continue?[y/n] " yn
+		read -r -p "Are you sure you want to continue?[y/n] " yn
 		case $yn in
 			[Yy]*)
 				init
@@ -229,9 +229,9 @@ case "$COMMAND" in
 		echo "$tags"
 		echo
 
-		read -p "Please enter the tag you want to update to: " tag
+		read -r -p "Please enter the tag you want to update to: " tag
 
-		if ! git describe --exact-match --tags $tag &>/dev/null ; then
+		if ! git describe --exact-match --tags "$tag" &>/dev/null ; then
 			echo
 			echo "❌  ERROR"
 			echo
@@ -247,7 +247,7 @@ case "$COMMAND" in
 		echo  "This will update the \`ckeditor-dev\` submodule to point	to the $tag tag"
 		echo
 
-		read -p "Are you sure you want to continue?[y/n] " yn
+		read -r -p "Are you sure you want to continue?[y/n] " yn
 		case $yn in
 			[Yy]*)
 				git reset --hard HEAD


### PR DESCRIPTION
Running shellcheck[1] finds a number of "Bash-isms" and a few other issues:

- SC2006: Use $(...) notation instead of legacy backticked `...`.
  (https://www.shellcheck.net/wiki/SC2006)
- SC2039: In POSIX sh, &> is undefined.
  (https://www.shellcheck.net/wiki/SC2039)
- SC2086: Double quote to prevent globbing and word splitting.
  (https://www.shellcheck.net/wiki/SC2086)
- SC2112: 'function' keyword is non-standard. Delete it.
  (https://www.shellcheck.net/wiki/SC2112)
- SC2162: read without -r will mangle backslashes.
  (https://www.shellcheck.net/wiki/SC2162)

Full output:

https://gist.github.com/wincent/6de88b13a10f9609e7f6293f27dab3da

Rather than fix all of those, I switched the shebang line to `#!/bin/bash`, and then fixed the smaller number of remaining issues:

- SC2006: Use $(...) notation instead of legacy backticked `...`.
  (https://www.shellcheck.net/wiki/SC2006)
- SC2086: Double quote to prevent globbing and word splitting.
  (https://www.shellcheck.net/wiki/SC2086)
- SC2162: read without -r will mangle backslashes.
  (https://www.shellcheck.net/wiki/SC2162)

Full output:

https://gist.github.com/wincent/83f2d51a2567a5edb9a705f5e0a0a25d

[1] https://www.shellcheck.net/ - https://github.com/koalaman/shellcheck