### PR TITLE
fix: work around different Git behavior across versions

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -92,7 +92,7 @@ case "$COMMAND" in
 		check
 
 		# Save SHA1 for later
-		sha1=$(git submodule | grep ckeditor-dev | awk '{print $1}' | sed -e s/[^0-9a-f]//)
+		sha1=$(git submodule status --cached -- ckeditor-dev | awk '{print $1}' | sed -e s/[^0-9a-f]//)
 
 		cd ckeditor-dev
 


### PR DESCRIPTION
This fixes broken `ck.sh patch` on some machines.

We have observed some different behavior testing this on a Windows machine running a different version of Git:

- On the Windows version being tested, `git submodule` would print the *worktree* SHA1 of the submodule.
- On macOS, it would print the *index* (or HEAD) SHA1.
- Additionally, I noticed that the behavior was different if run interactively or as part of a script: interactively, I was getting the worktree SHA1; in the script I was getting the index/HEAD SHA1.

This manifested on windows as always producing empty patch sets because it would effectively run commands like:

    git log --oneline HEAD..HEAD
    git format-patch HEAD -o ../patches

when it should have been running ones like:

    git log --oneline $PREVIOUS_HEAD..HEAD
    git format-patch $PREVIOUS_HEAD -o ../patches

It seems that we can force the index/HEAD SHA1 to be used by replacing our `git submodule` invocation with `git submodule status --cached -- $PATH_TO_SUBMODULE`.