### PR TITLE
fix: stabilize formatting of autogenerated commits

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -271,11 +271,11 @@ case "$COMMAND" in
 				git clean -fdx
 				git checkout "$tag"
 
-				commitmsg=$(git log --oneline | head -1)
+				commitmsg=$(git log -1 --pretty=format:"Update ckeditor-dev to $tag%n%n%h (tag: $tag) %s")
 
 				cd ..
 				git add -f ckeditor-dev
-				git commit -m "Update ckeditor-dev to $commitmsg"
+				git commit -m "$commitmsg"
 
 				echo "Do you want to rebase the updated ckeditor submodule with the liferay branch?"
 				echo


### PR DESCRIPTION
The `git log` command we were using here is sensitive to user-local configuration (see the "log.decorate" option in `man git-config`, for example), which means that one user running the update might produce a commit message like:

    Update ckeditor-dev to e1836357e (HEAD, tag: 4.11.4, origin/release/4.11.x) SCAYT/WSC changelog corrected.

and another might produce:

    Update ckeditor-dev to e1836357e (tag: 4.11.4) SCAYT/WSC changelog corrected.

Make it totally stable by explicitly providing a format string, which will make the messages look this this:

    Update ckeditor-dev to 4.11.4

    e1836357e (tag: 4.11.4) SCAYT/WSC changelog corrected.

The other small improvement here is avoiding the unnecessary fork of a separate "head" process by passing "-1" to `git log` with equivalent effect.

Test plan: Run `./ck.sh update` and see that it makes a commit like this:

    commit 92c6594d08a30c242de1f239d73477ebf4964ef9
    Author: Greg Hurrell <greg.hurrell@liferay.com>
    Date:   Wed Feb 5 09:37:29 2020 +0100

        Update ckeditor-dev to 4.13.1

        411985373 (tag: 4.13.1) Updated language files.