### PR TITLE
refactor: make patches consistent

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,8 +1,10 @@
-From 4547e662fcab2d1e310cf2b4a8793929d2fbd255 Mon Sep 17 00:00:00 2001
+From a73a61e100ee67f37ef84eb9d7a07187cea3d01d Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
-Subject: [PATCH 1/2] patch: LPS-89596 Changed position of drag icon for IE.
+Subject: [PATCH 1/2] LPS-89596 Cannot Drag Image from top content line in IE11
+ using Alloy Editor
 
+Changed position of drag icon for IE.
 ---
  plugins/widget/plugin.js | 4 ++++
  1 file changed, 4 insertions(+)
@@ -23,5 +25,5 @@ index aa32f0de5..289684816 100644
  				return;
  
 -- 
-2.20.1
+2.25.0
 

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,9 +1,11 @@
-From 991d4c88fd5da251b784cf87975538e1e82413bb Mon Sep 17 00:00:00 2001
+From fc4c56ae73205fac944048c78373b91f456c80cc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
-Subject: [PATCH 2/2] LPS-95472 Use width: inherit instead of width: 100% to
- work with the maximize plugin
+Subject: [PATCH 2/2] LPS-95472 Tabs in popups not appears correctly in
+ maximized CKEditor
 
+Use `width: inherit` instead of `width: 100%` to work with the maximize
+plugin.
 ---
  plugins/dialog/plugin.js | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -22,5 +24,5 @@ index 20f1ce6aa..c678b7a84 100644
  				contentMap = this._.contents[ contents.id ] = {},
  				cursor,
 -- 
-2.20.1
+2.25.0
 


### PR DESCRIPTION
Just a little thing that has been bugging me for a while now: our patch files were using inconsistent titles (one had a "patch:" prefix and the other didn't).

Seeing as these patches are always driven by changes needed in liferay-portal, and they always have LPS tickets associated with them, I dropped the prefix so that both start with an LPS number. I also tweaked the commit messages so that the title contains the issue title from JIRA (ie. the motivation for the change) and the body contains whatever additional explanation (ie. the details of the change) were previously in the commit message.

No impact on build structure (no code changes), so I am not going to redo the build.