### PR TITLE
fix: explicitly define files to be included in the release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "liferay-ckeditor",
   "version": "4.13.1-liferay.2",
   "description": "Liferay's fork of CKEditor",
+  "files": [
+    "ckeditor/**/*"
+  ],
   "main": "ckeditor/ckeditor.js",
   "repository": "https://github.com/liferay/liferay-ckeditor",
   "license": "(GPL-2.0-or-later OR LGPL-2.1 OR MPL-1.1)",


### PR DESCRIPTION
Because the 4.13.1-liferay.2 release that I just published contains only:

    ckeditor
    └── ckeditor.js

    0 directories, 1 file

If you compare that with the previous one, you see:

    ckeditor
    ...
    ├── ckeditor.js
    ....
    └── styles.js

    191 directories, 1287 files

Cause was almost certainly the addition of the `.gitignore` file in dc0f150772a112f87444a34f4, which `yarn` evidently takes as a cue to not ship anything at all other than the file indicated by the "main" field in the package.json.

Test plan: Run `npm publish --dry-run` and see that the tarball contents look a whole lot more healthy:

https://gist.github.com/wincent/97c394b6d14fe1418647c4c9088b021f