### PR TITLE
fix: make globs work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preversion": "yarn ci",
     "version": "node version.js",
     "postversion": "npx liferay-js-publish",
-    "format": "prettier --write '*.js' '*.json' '*.md'",
-    "format:check": "prettier --list-different '*.js' '*.json' '*.md'"
+    "format": "prettier --write \"*.js\" \"*.json\" \"*.md\"",
+    "format:check": "prettier --list-different \"*.js\" \"*.json\" \"*.md\""
   }
 }


### PR DESCRIPTION
Analogous change to this one on the alloy-editor repo:

https://github.com/liferay/alloy-editor/pull/1374

Just in case anybody is ever foolhardy enough to try doing development on this repo on Windows.