### PR TITLE
feat: run "yarn ci" on PRs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install -g yarn
+    - run: yarn ci
+      env:
+        CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,5 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
 
 name: Node.js CI
 
@@ -25,6 +24,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install -g yarn
+    - run: yarn
     - run: yarn ci
       env:
         CI: true

--- a/build-config.js
+++ b/build-config.js
@@ -29,7 +29,7 @@ var CKBUILDER_CONFIG = {
         "node_modules",
         "package.json",
         "README.md",
-        "tests",
+        "tests"
     ],
     plugins: {
         a11yhelp: 1,
@@ -87,6 +87,6 @@ var CKBUILDER_CONFIG = {
         templates: 1,
         toolbar: 1,
         undo: 1,
-        wysiwygarea: 1,
-    },
+        wysiwygarea: 1
+    }
 };


### PR DESCRIPTION
Following the pattern as described here:

https://codyogden.blog/yarn-with-github-actions-ci-cd/

Which is to start with the "Node.js starter workflow" and edit from there.

Going with single Node version because `yarn ci` only checks formatting at this point.

Closes: https://github.com/liferay/liferay-ckeditor/issues/49