### PR TITLE
docs: add build status badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
 
-name: Node.js CI
+name: ci
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # liferay-ckeditor
 
+![](https://github.com/liferay/liferay-ckeditor/workflows/ci/badge.svg)
+
 This repo contains tooling for maintaining Liferay's customized version of CKEditor.
 
 ## Structure


### PR DESCRIPTION
Renames "Node.js CI" to "ci" and adds a badge showing status to the README.