### PR TITLE
chore: set up semantic PR bot in this repo

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,7 @@
+---
+# Configuration for the Semantic Pull Request bot.
+# https://github.com/probot/semantic-pull-requests
+
+allowMergeCommits: true
+
+titleAndCommits: true


### PR DESCRIPTION
Using the same config as we've used successfully elsewhere (eg. [in AlloyEditor](https://github.com/liferay/alloy-editor/blob/840470674882e00d639e809a0ee3870b191cb23b/.github/semantic.yml)).

Noticed that we didn't have it configured already while reviewing [#59](https://github.com/liferay/liferay-ckeditor/pull/59).