### PR TITLE
fix: bad path in support/version.js

### DIFF
--- a/support/version.js
+++ b/support/version.js
@@ -46,7 +46,7 @@ function checkVersion() {
 
 	try {
 		const source = fs.readFileSync(
-			path.join(__dirname, 'ckeditor', 'ckeditor.js'),
+			path.join(__dirname, '..', 'ckeditor', 'ckeditor.js'),
 			'utf8'
 		);
 


### PR DESCRIPTION
Broken by: 002fd0c56d5c304a0166b2fbced0d04058e26d73