### PR TITLE
fix: other bad path in support/version.js

### DIFF
--- a/support/version.js
+++ b/support/version.js
@@ -23,7 +23,7 @@ function checkVersion() {
 	let ckeditorVersion;
 
 	try {
-		({version: ckeditorVersion} = require('./ckeditor-dev/package.json'));
+		({version: ckeditorVersion} = require('../ckeditor-dev/package.json'));
 	} catch (_error) {
 		die('Unable to read version from ckeditor-dev/package.json');
 	}


### PR DESCRIPTION
Because 5941e58ae0f25a39d7a507b5b38aa0d5af770c7a was only a partial fix.