### PR TITLE
feat: customize moono-lexicon skin

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"preversion": "yarn ci",
 		"version": "node support/version.js",
 		"postversion": "npx liferay-js-publish",
-		"format": "prettier --write \"support/*.js\" \"*.json\" \"*.md\"",
+		"format": "prettier --write \"skins/**/*.css\" \"support/*.js\" \"*.json\" \"*.md\"",
 		"format:check": "prettier --list-different \"support/*.js\" \"*.json\" \"*.md\""
 	}
 }

--- a/skins/moono-lexicon/colorpanel.css
+++ b/skins/moono-lexicon/colorpanel.css
@@ -48,60 +48,52 @@ The COLOR PALETTE section instead is a table with a variable number of cells
 */
 
 /* The container of the color palette. */
-.cke_colorblock
-{
+.cke_colorblock {
 	padding: 10px;
 	font-size: 11px;
 	font-family: 'Microsoft Sans Serif', Tahoma, Arial, Verdana, Sans-Serif;
 }
 
 .cke_colorblock,
-.cke_colorblock a
-{
+.cke_colorblock a {
 	text-decoration: none;
 	color: #000;
 }
 
 /* The wrapper of the span.cke_colorbox. It provides an extra border and padding. */
-a.cke_colorbox
-{
+a.cke_colorbox {
 	padding: 2px;
 	float: left;
 	width: 20px;
 	height: 20px;
 }
 
-.cke_rtl a.cke_colorbox
-{
+.cke_rtl a.cke_colorbox {
 	float: right;
 }
 
 /* Different states of the a.cke_colorbox wrapper. */
 a:hover.cke_colorbox,
 a:focus.cke_colorbox,
-a:active.cke_colorbox
-{
+a:active.cke_colorbox {
 	outline: none;
 	padding: 0;
-	border: 2px solid #139FF7;
+	border: 2px solid #139ff7;
 }
 
-a:hover.cke_colorbox
-{
+a:hover.cke_colorbox {
 	border-color: #bcbcbc;
 }
 
 /* The box which is to represent a single color on the color palette.
    It is a small, square-shaped element which can be selected from the palette. */
-span.cke_colorbox
-{
+span.cke_colorbox {
 	width: 20px;
 	height: 20px;
 	float: left;
 }
 
-.cke_rtl span.cke_colorbox
-{
+.cke_rtl span.cke_colorbox {
 	float: right;
 }
 
@@ -110,16 +102,14 @@ span.cke_colorbox
    - cke_colormore (BOTTOM) executes the color dialog.
 */
 a.cke_colorauto,
-a.cke_colormore
-{
+a.cke_colormore {
 	border: #fff 1px solid;
 	padding: 3px;
 	display: block;
 	cursor: pointer;
 }
 
-a.cke_colorauto
-{
+a.cke_colorauto {
 	padding: 0;
 	border: 1px solid transparent;
 	margin-bottom: 6px;
@@ -127,8 +117,7 @@ a.cke_colorauto
 	line-height: 26px;
 }
 
-a.cke_colormore
-{
+a.cke_colormore {
 	margin-top: 10px;
 	height: 20px;
 	line-height: 19px;
@@ -140,21 +129,18 @@ a:hover.cke_colormore,
 a:focus.cke_colorauto,
 a:focus.cke_colormore,
 a:active.cke_colorauto,
-a:active.cke_colormore
-{
+a:active.cke_colormore {
 	outline: none;
-	border: #139FF7 1px solid;
+	border: #139ff7 1px solid;
 	background-color: #f8f8f8;
 }
 
 a:hover.cke_colorauto,
-a:hover.cke_colormore
-{
+a:hover.cke_colormore {
 	border-color: #bcbcbc;
 }
 
-.cke_colorauto span.cke_colorbox
-{
+.cke_colorauto span.cke_colorbox {
 	width: 18px;
 	height: 18px;
 	border: 1px solid #808080;
@@ -162,8 +148,7 @@ a:hover.cke_colormore
 	margin-top: 3px;
 }
 
-.cke_rtl .cke_colorauto span.cke_colorbox
-{
+.cke_rtl .cke_colorauto span.cke_colorbox {
 	margin-left: 0;
 	margin-right: 1px;
 }
@@ -175,8 +160,7 @@ span.cke_colorbox[style="background-color:#FFF"],
 
 /* IE, Edge */
 span.cke_colorbox[style*="rgb(255,255,255)"],
-span.cke_colorbox[style*="rgb(255, 255, 255)"]
-{
+span.cke_colorbox[style*="rgb(255, 255, 255)"] {
 	border: 1px solid #808080;
 	width: 18px;
 	height: 18px;

--- a/skins/moono-lexicon/dialog.css
+++ b/skins/moono-lexicon/dialog.css
@@ -40,29 +40,25 @@ Comments in this file will give more details about each of the above blocks.
 */
 
 /* The outer container of the dialog. */
-.cke_dialog
-{
+.cke_dialog {
 	/* Mandatory: Because the dialog.css file is loaded on demand, we avoid
 		showing an unstyled dialog by hidding it. Here, we restore its visibility. */
 	visibility: visible;
 }
 
 /* The inner boundary container. */
-.cke_dialog_body
-{
+.cke_dialog_body {
 	z-index: 1;
 	background: #fff;
 }
 
 /* Due to our reset we have to recover the styles of some elements. */
-.cke_dialog strong
-{
+.cke_dialog strong {
 	font-weight: bold;
 }
 
 /* The dialog title. */
-.cke_dialog_title
-{
+.cke_dialog_title {
 	font-weight: bold;
 	font-size: 12px;
 	cursor: move;
@@ -77,8 +73,7 @@ Comments in this file will give more details about each of the above blocks.
 	letter-spacing: 0.3px;
 }
 
-.cke_dialog_spinner
-{
+.cke_dialog_spinner {
 	border-radius: 50%;
 
 	width: 12px;
@@ -96,16 +91,14 @@ Comments in this file will give more details about each of the above blocks.
 
 /* A GIF fallback for IE8 and IE9 which does not support CSS animations. */
 .cke_browser_ie8 .cke_dialog_spinner,
-.cke_browser_ie9 .cke_dialog_spinner
-{
+.cke_browser_ie9 .cke_dialog_spinner {
 	background: url(images/spinner.gif) center top no-repeat;
 	width: 16px;
 	height: 16px;
 	border: 0;
 }
 
-@-webkit-keyframes dialog_spinner
-{
+@-webkit-keyframes dialog_spinner {
 	0% {
 		-webkit-transform: rotate(0deg);
 		transform: rotate(0deg);
@@ -116,8 +109,7 @@ Comments in this file will give more details about each of the above blocks.
 	}
 }
 
-@keyframes dialog_spinner
-{
+@keyframes dialog_spinner {
 	0% {
 		-webkit-transform: rotate(0deg);
 		transform: rotate(0deg);
@@ -130,8 +122,7 @@ Comments in this file will give more details about each of the above blocks.
 
 /* The outer part of the dialog contents, which contains the contents body
    and the footer. */
-.cke_dialog_contents
-{
+.cke_dialog_contents {
 	background-color: #fff;
 	overflow: auto;
 	padding: 15px 10px 5px 10px;
@@ -140,8 +131,7 @@ Comments in this file will give more details about each of the above blocks.
 }
 
 /* The contents body part, which will hold all elements available in the dialog. */
-.cke_dialog_contents_body
-{
+.cke_dialog_contents_body {
 	overflow: auto;
 	padding: 9px 10px 5px 10px;
 	margin-top: 22px;
@@ -149,37 +139,31 @@ Comments in this file will give more details about each of the above blocks.
 
 /* The dialog footer, which usually contains the "Ok" and "Cancel" buttons as
    well as a resize handler. */
-.cke_dialog_footer
-{
+.cke_dialog_footer {
 	text-align: right;
 	position: relative;
 	border-top: 1px solid #d1d1d1;
 	background: #f8f8f8;
 }
 
-.cke_rtl .cke_dialog_footer
-{
+.cke_rtl .cke_dialog_footer {
 	text-align: left;
 }
 
-.cke_hc .cke_dialog_footer
-{
+.cke_hc .cke_dialog_footer {
 	outline: none;
 	border-top: 1px solid #fff;
 }
 
-.cke_dialog .cke_resizer
-{
+.cke_dialog .cke_resizer {
 	margin-top: 22px;
 }
 
-.cke_dialog .cke_resizer_rtl
-{
+.cke_dialog .cke_resizer_rtl {
 	margin-left: 5px;
 }
 
-.cke_dialog .cke_resizer_ltr
-{
+.cke_dialog .cke_resizer_ltr {
 	margin-right: 5px;
 }
 
@@ -205,8 +189,7 @@ The .cke_dialog_tab_selected class is appended to the active tab.
 */
 
 /* The main tabs container. */
-.cke_dialog_tabs
-{
+.cke_dialog_tabs {
 	height: 33px;
 	display: inline-block;
 	margin: 9px 0 0;
@@ -215,15 +198,13 @@ The .cke_dialog_tab_selected class is appended to the active tab.
 	left: 11px;
 }
 
-.cke_rtl .cke_dialog_tabs
-{
+.cke_rtl .cke_dialog_tabs {
 	left: auto;
 	right: 11px;
 }
 
 /* A single tab (an <a> element). */
-a.cke_dialog_tab
-{
+a.cke_dialog_tab {
 	height: 25px;
 	padding: 4px 8px;
 	display: inline-block;
@@ -244,13 +225,11 @@ a.cke_dialog_tab
 }
 
 /* A hover state of a regular inactive tab. */
-a.cke_dialog_tab:hover
-{
+a.cke_dialog_tab:hover {
 	background-color: #fff;
 }
 
-a.cke_dialog_tab:focus
-{
+a.cke_dialog_tab:focus {
 	border: 2px solid #139ff7;
 	border-bottom-color: #d1d1d1;
 	padding: 3px 7px;
@@ -259,8 +238,7 @@ a.cke_dialog_tab:focus
 }
 
 /* Single selected tab. */
-a.cke_dialog_tab_selected
-{
+a.cke_dialog_tab_selected {
 	background: #fff;
 	border-bottom-color: #fff;
 	cursor: default;
@@ -269,42 +247,36 @@ a.cke_dialog_tab_selected
 
 /* A hover state for selected tab. */
 a.cke_dialog_tab_selected:hover,
-a.cke_dialog_tab_selected:focus
-{
+a.cke_dialog_tab_selected:focus {
 	border-bottom-color: #fff;
 }
 
 .cke_hc a.cke_dialog_tab:hover,
 .cke_hc a.cke_dialog_tab:focus,
-.cke_hc a.cke_dialog_tab_selected
-{
+.cke_hc a.cke_dialog_tab_selected {
 	border: 3px solid;
 	padding: 2px 6px;
 }
 
-a.cke_dialog_tab_disabled
-{
+a.cke_dialog_tab_disabled {
 	color: #bababa;
 	cursor: default;
 }
 
 /* The .cke_single_page class is appended to the dialog outer element in case
    of dialogs that has no tabs. */
-.cke_single_page .cke_dialog_tabs
-{
+.cke_single_page .cke_dialog_tabs {
 	display: none;
 }
 
-.cke_single_page .cke_dialog_contents
-{
+.cke_single_page .cke_dialog_contents {
 	padding-top: 5px;
 	margin-top: 0;
 	border-top: none;
 }
 
 /* The close button at the top of the dialog. */
-a.cke_dialog_close_button
-{
+a.cke_dialog_close_button {
 	background-image: url(images/close.png);
 	background-repeat: no-repeat;
 	background-position: 50%;
@@ -320,13 +292,11 @@ a.cke_dialog_close_button
 	filter: alpha(opacity = 70);
 }
 
-.cke_rtl .cke_dialog_close_button
-{
+.cke_rtl .cke_dialog_close_button {
 	left: 12px;
 }
 
-.cke_ltr .cke_dialog_close_button
-{
+.cke_ltr .cke_dialog_close_button {
 	right: 12px;
 }
 
@@ -334,25 +304,21 @@ a.cke_dialog_close_button
 	background-image: none;
 }
 
-.cke_hidpi a.cke_dialog_close_button
-{
+.cke_hidpi a.cke_dialog_close_button {
 	background-image: url(images/hidpi/close.png);
 	background-size: 16px;
 }
 
-a.cke_dialog_close_button:hover
-{
+a.cke_dialog_close_button:hover {
 	opacity: 1;
 	filter: alpha(opacity = 100);
 }
 
-a.cke_dialog_close_button span
-{
+a.cke_dialog_close_button span {
 	display: none;
 }
 
-.cke_hc a.cke_dialog_close_button span
-{
+.cke_hc a.cke_dialog_close_button span {
 	display: inline;
 	cursor: pointer;
 	font-weight: bold;
@@ -375,8 +341,7 @@ the same labelling structure, having the label text inside an element with
 
 /* If an element is supposed to be disabled, the .cke_disabled class is
    appended to it. */
-div.cke_disabled .cke_dialog_ui_labeled_content div *
-{
+div.cke_disabled .cke_dialog_ui_labeled_content div * {
 	background-color: #ddd;
 	cursor: default;
 }
@@ -400,50 +365,42 @@ It is possible to have nested V/H-Boxes.
 */
 
 .cke_dialog_ui_vbox table,
-.cke_dialog_ui_hbox table
-{
+.cke_dialog_ui_hbox table {
 	margin: auto;
 }
 
-.cke_dialog_ui_vbox_child
-{
+.cke_dialog_ui_vbox_child {
 	padding: 5px 0px;
 }
 
-.cke_dialog_ui_hbox
-{
+.cke_dialog_ui_hbox {
 	width: 100%;
 	margin-top: 12px;
 }
 
 .cke_dialog_ui_hbox_first,
 .cke_dialog_ui_hbox_child,
-.cke_dialog_ui_hbox_last
-{
+.cke_dialog_ui_hbox_last {
 	vertical-align: top;
 }
 
 .cke_ltr .cke_dialog_ui_hbox_first,
-.cke_ltr .cke_dialog_ui_hbox_child
-{
+.cke_ltr .cke_dialog_ui_hbox_child {
 	padding-right: 10px;
 }
 
 .cke_rtl .cke_dialog_ui_hbox_first,
-.cke_rtl .cke_dialog_ui_hbox_child
-{
+.cke_rtl .cke_dialog_ui_hbox_child {
 	padding-left: 10px;
 }
 
 .cke_ltr .cke_dialog_footer_buttons .cke_dialog_ui_hbox_first,
-.cke_ltr .cke_dialog_footer_buttons .cke_dialog_ui_hbox_child
-{
+.cke_ltr .cke_dialog_footer_buttons .cke_dialog_ui_hbox_child {
 	padding-right: 5px;
 }
 
 .cke_rtl .cke_dialog_footer_buttons .cke_dialog_ui_hbox_first,
-.cke_rtl .cke_dialog_footer_buttons .cke_dialog_ui_hbox_child
-{
+.cke_rtl .cke_dialog_footer_buttons .cke_dialog_ui_hbox_child {
 	padding-left: 5px;
 	padding-right: 0;
 }
@@ -454,8 +411,7 @@ It is possible to have nested V/H-Boxes.
 .cke_hc div.cke_dialog_ui_input_tel,
 .cke_hc div.cke_dialog_ui_input_textarea,
 .cke_hc div.cke_dialog_ui_input_select,
-.cke_hc div.cke_dialog_ui_input_file
-{
+.cke_hc div.cke_dialog_ui_input_file {
 	border: 1px solid;
 }
 
@@ -499,8 +455,7 @@ The textarea field to input larger text.
 +-----------------------------------------------------+
 */
 
-textarea.cke_dialog_ui_input_textarea
-{
+textarea.cke_dialog_ui_input_textarea {
 	overflow: auto;
 	resize: none;
 }
@@ -508,8 +463,7 @@ textarea.cke_dialog_ui_input_textarea
 input.cke_dialog_ui_input_text,
 input.cke_dialog_ui_input_password,
 input.cke_dialog_ui_input_tel,
-textarea.cke_dialog_ui_input_textarea
-{
+textarea.cke_dialog_ui_input_textarea {
 	background-color: #fff;
 	border: 1px solid #bcbcbc;
 	padding: 4px 6px;
@@ -528,8 +482,7 @@ textarea.cke_dialog_ui_input_textarea
 input.cke_dialog_ui_input_text:hover,
 input.cke_dialog_ui_input_password:hover,
 input.cke_dialog_ui_input_tel:hover,
-textarea.cke_dialog_ui_input_textarea:hover
-{
+textarea.cke_dialog_ui_input_textarea:hover {
 	border: 1px solid #aeb3b9;
 }
 
@@ -537,31 +490,26 @@ input.cke_dialog_ui_input_text:focus,
 input.cke_dialog_ui_input_password:focus,
 input.cke_dialog_ui_input_tel:focus,
 textarea.cke_dialog_ui_input_textarea:focus,
-select.cke_dialog_ui_input_select:focus
-{
+select.cke_dialog_ui_input_select:focus {
 	outline: none;
 	border: 2px solid #139ff7;
 }
 
-input.cke_dialog_ui_input_text:focus
-{
+input.cke_dialog_ui_input_text:focus {
 	padding-left: 5px;
 }
 
-textarea.cke_dialog_ui_input_textarea:focus
-{
+textarea.cke_dialog_ui_input_textarea:focus {
 	padding: 3px 5px;
 }
 
-select.cke_dialog_ui_input_select:focus
-{
+select.cke_dialog_ui_input_select:focus {
 	margin: 0;
 	width: 100% !important;
 }
 
 input.cke_dialog_ui_checkbox_input,
-input.cke_dialog_ui_radio_input
-{
+input.cke_dialog_ui_radio_input {
 	margin-left: 1px;
 	margin-right: 2px;
 }
@@ -569,8 +517,7 @@ input.cke_dialog_ui_radio_input
 input.cke_dialog_ui_checkbox_input:focus,
 input.cke_dialog_ui_checkbox_input:active,
 input.cke_dialog_ui_radio_input:focus,
-input.cke_dialog_ui_radio_input:active
-{
+input.cke_dialog_ui_radio_input:active {
 	border: none;
 	outline: 2px solid #139ff7;
 }
@@ -589,8 +536,7 @@ The buttons used in the dialog footer or inside the contents.
 */
 
 /* The outer part of the button. */
-a.cke_dialog_ui_button
-{
+a.cke_dialog_ui_button {
 	display: inline-block;
 	*display: inline;
 	*zoom: 1;
@@ -610,29 +556,24 @@ a.cke_dialog_ui_button
 	letter-spacing: 0.3px;
 	line-height: 18px;
 	box-sizing: border-box;
-
 }
 
 .cke_hc a.cke_dialog_ui_button {
 	border-width: 3px;
 }
 
-
-span.cke_dialog_ui_button
-{
+span.cke_dialog_ui_button {
 	padding: 0 10px;
 	cursor: pointer;
 }
 
-a.cke_dialog_ui_button:hover
-{
+a.cke_dialog_ui_button:hover {
 	background: #fff;
 }
 
 /* 	:focus/:active styles for dialog buttons: regular and footer. */
 a.cke_dialog_ui_button:focus,
-a.cke_dialog_ui_button:active
-{
+a.cke_dialog_ui_button:active {
 	border: 2px solid #139ff7;
 	outline: none;
 	padding: 3px 0;
@@ -640,14 +581,12 @@ a.cke_dialog_ui_button:active
 
 .cke_hc a.cke_dialog_ui_button:hover,
 .cke_hc a.cke_dialog_ui_button:focus,
-.cke_hc a.cke_dialog_ui_button:active
-{
+.cke_hc a.cke_dialog_ui_button:active {
 	border: 3px solid;
 }
 
 /* The inner part of the button (both in dialog tabs and dialog footer). */
-.cke_dialog_footer_buttons a.cke_dialog_ui_button span
-{
+.cke_dialog_footer_buttons a.cke_dialog_ui_button span {
 	color: inherit;
 	font-size: 12px;
 	font-weight: bold;
@@ -655,57 +594,48 @@ a.cke_dialog_ui_button:active
 }
 
 /* Special class appended to the Ok button. */
-a.cke_dialog_ui_button_ok
-{
+a.cke_dialog_ui_button_ok {
 	color: #fff;
-	background: #09863E;
-	border: 1px solid #09863E;
+	background: #09863e;
+	border: 1px solid #09863e;
 }
 
 .cke_hc a.cke_dialog_ui_button {
 	border: 3px solid #bcbcbc;
 }
 
-
-a.cke_dialog_ui_button_ok:hover
-{
-	background: #53AA78;
-	border-color: #53AA78;
+a.cke_dialog_ui_button_ok:hover {
+	background: #53aa78;
+	border-color: #53aa78;
 }
 
-a.cke_dialog_ui_button_ok:focus
-{
-	box-shadow: inset 0 0 0 2px #FFF;
+a.cke_dialog_ui_button_ok:focus {
+	box-shadow: inset 0 0 0 2px #fff;
 }
 
 a.cke_dialog_ui_button_ok:focus,
-a.cke_dialog_ui_button_ok:active
-{
+a.cke_dialog_ui_button_ok:active {
 	border-color: #139ff7;
 }
 
 .cke_hc a.cke_dialog_ui_button_ok:hover,
 .cke_hc a.cke_dialog_ui_button_ok:focus,
-.cke_hc a.cke_dialog_ui_button_ok:active
-{
+.cke_hc a.cke_dialog_ui_button_ok:active {
 	border-color: #484848;
 }
 
-a.cke_dialog_ui_button_ok.cke_disabled
-{
+a.cke_dialog_ui_button_ok.cke_disabled {
 	background: #d1d1d1;
 	border-color: #d1d1d1;
 	cursor: default;
 }
 
-a.cke_dialog_ui_button_ok.cke_disabled span
-{
+a.cke_dialog_ui_button_ok.cke_disabled span {
 	cursor: default;
 }
 
 /* A special container that holds the footer buttons. */
-.cke_dialog_footer_buttons
-{
+.cke_dialog_footer_buttons {
 	display: inline-table;
 	margin: 5px;
 	width: auto;
@@ -714,13 +644,11 @@ a.cke_dialog_ui_button_ok.cke_disabled span
 }
 
 /* Styles for other dialog element types. */
-div.cke_dialog_ui_input_select
-{
+div.cke_dialog_ui_input_select {
 	display: table;
 }
 
-select.cke_dialog_ui_input_select
-{
+select.cke_dialog_ui_input_select {
 	height: 28px;
 	line-height: 28px;
 
@@ -734,46 +662,39 @@ select.cke_dialog_ui_input_select
 	width: calc(100% - 2px) !important;
 }
 
-.cke_dialog_ui_input_file
-{
+.cke_dialog_ui_input_file {
 	width: 100%;
 	height: 25px;
 }
 
 .cke_hc .cke_dialog_ui_labeled_content input:focus,
 .cke_hc .cke_dialog_ui_labeled_content select:focus,
-.cke_hc .cke_dialog_ui_labeled_content textarea:focus
-{
+.cke_hc .cke_dialog_ui_labeled_content textarea:focus {
 	outline: 1px dotted;
 }
 
-.cke_dialog_ui_labeled_label
-{
+.cke_dialog_ui_labeled_label {
 	margin-left: 1px;
 }
 
 /*
  * Some utility CSS classes for dialog authors.
  */
-.cke_dialog .cke_dark_background
-{
+.cke_dialog .cke_dark_background {
 	/* In moono-lexicon .cke_dark_background in a dialog is transparent.
 		Done this way to be consistent in all plugins. */
 	background-color: transparent;
 }
 
-.cke_dialog .cke_light_background
-{
-	background-color: #EBEBEB;
+.cke_dialog .cke_light_background {
+	background-color: #ebebeb;
 }
 
-.cke_dialog .cke_centered
-{
+.cke_dialog .cke_centered {
 	text-align: center;
 }
 
-.cke_dialog a.cke_btn_reset
-{
+.cke_dialog a.cke_btn_reset {
 	float: right;
 	background: url(images/refresh.png) top left no-repeat;
 	width: 16px;
@@ -782,20 +703,17 @@ select.cke_dialog_ui_input_select
 	font-size: 1px;
 }
 
-.cke_hidpi .cke_dialog a.cke_btn_reset
-{
+.cke_hidpi .cke_dialog a.cke_btn_reset {
 	background-size: 16px;
 	background-image: url(images/hidpi/refresh.png);
 }
 
-.cke_rtl .cke_dialog a.cke_btn_reset
-{
+.cke_rtl .cke_dialog a.cke_btn_reset {
 	float: left;
 }
 
 .cke_dialog a.cke_btn_locked,
-.cke_dialog a.cke_btn_unlocked
-{
+.cke_dialog a.cke_btn_unlocked {
 	float: left;
 	width: 16px;
 	height: 16px;
@@ -806,45 +724,37 @@ select.cke_dialog_ui_input_select
 
 .cke_dialog a.cke_btn_locked,
 .cke_dialog a.cke_btn_unlocked,
-.cke_dialog a.cke_btn_reset
-{
+.cke_dialog a.cke_btn_reset {
 	margin: 2px;
 }
 
-.cke_dialog a.cke_btn_locked
-{
+.cke_dialog a.cke_btn_locked {
 	background-image: url(images/lock.png);
 }
 
-.cke_dialog a.cke_btn_unlocked
-{
+.cke_dialog a.cke_btn_unlocked {
 	background-image: url(images/lock-open.png);
 }
 
 .cke_rtl .cke_dialog a.cke_btn_locked,
-.cke_rtl .cke_dialog a.cke_btn_unlocked
-{
+.cke_rtl .cke_dialog a.cke_btn_unlocked {
 	float: right;
 }
 
 .cke_hidpi .cke_dialog a.cke_btn_unlocked,
-.cke_hidpi .cke_dialog a.cke_btn_locked
-{
+.cke_hidpi .cke_dialog a.cke_btn_locked {
 	background-size: 16px;
 }
 
-.cke_hidpi .cke_dialog a.cke_btn_locked
-{
+.cke_hidpi .cke_dialog a.cke_btn_locked {
 	background-image: url(images/hidpi/lock.png);
 }
 
-.cke_hidpi .cke_dialog a.cke_btn_unlocked
-{
+.cke_hidpi .cke_dialog a.cke_btn_unlocked {
 	background-image: url(images/hidpi/lock-open.png);
 }
 
-.cke_dialog a.cke_btn_locked .cke_icon
-{
+.cke_dialog a.cke_btn_locked .cke_icon {
 	display: none;
 }
 
@@ -857,21 +767,18 @@ select.cke_dialog_ui_input_select
 .cke_dialog a.cke_btn_unlocked:active,
 .cke_dialog a.cke_btn_reset:hover,
 .cke_dialog a.cke_btn_reset:focus,
-.cke_dialog a.cke_btn_reset:active
-{
+.cke_dialog a.cke_btn_reset:active {
 	cursor: pointer;
 	outline: none;
 	margin: 0;
-	border: 2px solid #139FF7;
+	border: 2px solid #139ff7;
 }
 
-.cke_dialog fieldset
-{
+.cke_dialog fieldset {
 	border: 1px solid #bcbcbc;
 }
 
-.cke_dialog fieldset legend
-{
+.cke_dialog fieldset legend {
 	padding: 0 6px;
 }
 
@@ -886,8 +793,17 @@ select.cke_dialog_ui_input_select
 
 .cke_dialog_ui_checkbox .cke_dialog_ui_checkbox_input,
 .cke_dialog_ui_checkbox .cke_dialog_ui_checkbox_input + label,
-.cke_dialog fieldset .cke_dialog_ui_vbox .cke_dialog_ui_checkbox .cke_dialog_ui_checkbox_input,
-.cke_dialog fieldset .cke_dialog_ui_vbox .cke_dialog_ui_checkbox .cke_dialog_ui_checkbox_input + label {
+.cke_dialog
+	fieldset
+	.cke_dialog_ui_vbox
+	.cke_dialog_ui_checkbox
+	.cke_dialog_ui_checkbox_input,
+.cke_dialog
+	fieldset
+	.cke_dialog_ui_vbox
+	.cke_dialog_ui_checkbox
+	.cke_dialog_ui_checkbox_input
+	+ label {
 	vertical-align: middle;
 }
 
@@ -895,8 +811,7 @@ select.cke_dialog_ui_input_select
 The rest of the file contains style used on several common plugins. There is a
 tendency that these will be moved to the plugins code in the future.
 */
-.cke_dialog .ImagePreviewBox
-{
+.cke_dialog .ImagePreviewBox {
 	border: 1px ridge #bcbcbc;
 	overflow: scroll;
 	height: 200px;
@@ -905,13 +820,11 @@ tendency that these will be moved to the plugins code in the future.
 	background-color: white;
 }
 
-.cke_dialog .ImagePreviewBox table td
-{
+.cke_dialog .ImagePreviewBox table td {
 	white-space: normal;
 }
 
-.cke_dialog  .ImagePreviewLoader
-{
+.cke_dialog .ImagePreviewLoader {
 	position: absolute;
 	white-space: normal;
 	overflow: hidden;
@@ -925,8 +838,7 @@ tendency that these will be moved to the plugins code in the future.
 	background-color: #e4e4e4;
 }
 
-.cke_dialog .FlashPreviewBox
-{
+.cke_dialog .FlashPreviewBox {
 	white-space: normal;
 	border: 1px solid #bcbcbc;
 	overflow: auto;
@@ -936,21 +848,18 @@ tendency that these will be moved to the plugins code in the future.
 	background-color: white;
 }
 
-.cke_dialog .cke_pastetext
-{
+.cke_dialog .cke_pastetext {
 	width: 346px;
 	height: 170px;
 }
 
-.cke_dialog .cke_pastetext textarea
-{
+.cke_dialog .cke_pastetext textarea {
 	width: 340px;
 	height: 170px;
 	resize: none;
 }
 
-.cke_dialog iframe.cke_pasteframe
-{
+.cke_dialog iframe.cke_pasteframe {
 	width: 346px;
 	height: 130px;
 	background-color: white;
@@ -958,56 +867,47 @@ tendency that these will be moved to the plugins code in the future.
 	border-radius: 3px;
 }
 
-.cke_dialog .cke_hand
-{
+.cke_dialog .cke_hand {
 	cursor: pointer;
 }
 
-.cke_disabled
-{
+.cke_disabled {
 	color: #a0a0a0;
 }
 
-.cke_dialog_body .cke_label
-{
+.cke_dialog_body .cke_label {
 	display: none;
 }
 
-.cke_dialog_body label
-{
+.cke_dialog_body label {
 	display: inline;
 	cursor: default;
 	letter-spacing: 0.3px;
 }
 
-.cke_dialog_body label + .cke_dialog_ui_labeled_content
-{
+.cke_dialog_body label + .cke_dialog_ui_labeled_content {
 	margin-top: 2px;
 }
 
 .cke_dialog_contents_body .cke_dialog_ui_text,
 .cke_dialog_contents_body .cke_dialog_ui_select,
 /* Find Dialog */
-.cke_dialog_contents_body .cke_dialog_ui_hbox_last > a.cke_dialog_ui_button
-{
+.cke_dialog_contents_body .cke_dialog_ui_hbox_last > a.cke_dialog_ui_button {
 	margin-top: 4px;
 }
 
-a.cke_smile
-{
+a.cke_smile {
 	overflow: hidden;
 	display: block;
 	text-align: center;
 	padding: 0.3em 0;
 }
 
-a.cke_smile img
-{
+a.cke_smile img {
 	vertical-align: middle;
 }
 
-a.cke_specialchar
-{
+a.cke_specialchar {
 	cursor: inherit;
 	display: block;
 	height: 1.25em;
@@ -1016,8 +916,7 @@ a.cke_specialchar
 }
 
 a.cke_smile,
-a.cke_specialchar
-{
+a.cke_specialchar {
 	border: 2px solid transparent;
 }
 
@@ -1026,45 +925,39 @@ a.cke_smile:focus,
 a.cke_smile:active,
 a.cke_specialchar:hover,
 a.cke_specialchar:focus,
-a.cke_specialchar:active
-{
+a.cke_specialchar:active {
 	background: #fff;
 	outline: 0;
 }
 
 a.cke_smile:hover,
-a.cke_specialchar:hover
-{
+a.cke_specialchar:hover {
 	border-color: #888;
 }
 
 a.cke_smile:focus,
 a.cke_smile:active,
 a.cke_specialchar:focus,
-a.cke_specialchar:active
-{
-	border-color: #139FF7;
+a.cke_specialchar:active {
+	border-color: #139ff7;
 }
 
 /**
  * Styles specific to "cellProperties" dialog.
  */
 
-.cke_dialog_contents a.colorChooser
-{
+.cke_dialog_contents a.colorChooser {
 	display: block;
 	margin-top: 6px;
 	margin-left: 10px;
 	width: 80px;
 }
 
-.cke_rtl .cke_dialog_contents a.colorChooser
-{
+.cke_rtl .cke_dialog_contents a.colorChooser {
 	margin-right: 10px;
 }
 
-.cke_iframe_shim
-{
+.cke_iframe_shim {
 	display: block;
 	position: absolute;
 	top: 0;
@@ -1075,86 +968,72 @@ a.cke_specialchar:active
 	height: 100%;
 }
 
-.cke_dialog_contents_body .cke_accessibility_legend
-{
+.cke_dialog_contents_body .cke_accessibility_legend {
 	margin: 2px 7px 2px 2px;
 }
 
 .cke_dialog_contents_body .cke_accessibility_legend:focus,
-.cke_dialog_contents_body .cke_accessibility_legend:active
-{
+.cke_dialog_contents_body .cke_accessibility_legend:active {
 	outline: none;
-	border: 2px solid #139FF7;
+	border: 2px solid #139ff7;
 	margin: 0 5px 0 0;
 }
 
-.cke_dialog_contents_body input[type=file]:focus,
-.cke_dialog_contents_body input[type=file]:active
-{
-	border: 2px solid #139FF7;
+.cke_dialog_contents_body input[type='file']:focus,
+.cke_dialog_contents_body input[type='file']:active {
+	border: 2px solid #139ff7;
 }
 
 /* Specific dialog styles. Overridden in css to not break plugins compatibility with other skins. */
-.cke_dialog_find_fieldset
-{
+.cke_dialog_find_fieldset {
 	margin-top: 10px !important;
 }
 
-.cke_dialog_image_ratiolock
-{
+.cke_dialog_image_ratiolock {
 	margin-top: 52px !important;
 }
 
-.cke_dialog_forms_select_order label.cke_dialog_ui_labeled_label
-{
+.cke_dialog_forms_select_order label.cke_dialog_ui_labeled_label {
 	margin-left: 0;
 }
 
-.cke_dialog_forms_select_order div.cke_dialog_ui_input_select
-{
+.cke_dialog_forms_select_order div.cke_dialog_ui_input_select {
 	width: 100%;
 }
 
-.cke_dialog_forms_select_order_txtsize .cke_dialog_ui_hbox_last
-{
+.cke_dialog_forms_select_order_txtsize .cke_dialog_ui_hbox_last {
 	padding-top: 4px;
 }
 
 .cke_dialog_image_url .cke_dialog_ui_hbox_last,
-.cke_dialog_flash_url .cke_dialog_ui_hbox_last
-{
+.cke_dialog_flash_url .cke_dialog_ui_hbox_last {
 	vertical-align: bottom;
 }
 
-a.cke_dialog_ui_button.cke_dialog_image_browse
-{
+a.cke_dialog_ui_button.cke_dialog_image_browse {
 	margin-top: 10px;
 }
 
 /* Templates plugin. */
-.cke_dialog_contents_body .cke_tpl_list
-{
+.cke_dialog_contents_body .cke_tpl_list {
 	border: #bcbcbc 1px solid;
 	margin: 1px;
 }
 
 .cke_dialog_contents_body .cke_tpl_list:focus,
-.cke_dialog_contents_body .cke_tpl_list:active
-{
+.cke_dialog_contents_body .cke_tpl_list:active {
 	outline: none;
 	margin: 0;
-	border: 2px solid #139FF7;
+	border: 2px solid #139ff7;
 }
 
 .cke_dialog_contents_body .cke_tpl_list a:focus,
-.cke_dialog_contents_body .cke_tpl_list a:active
-{
+.cke_dialog_contents_body .cke_tpl_list a:active {
 	outline: none;
 }
 
 .cke_dialog_contents_body .cke_tpl_list a:focus .cke_tpl_item,
-.cke_dialog_contents_body .cke_tpl_list a:active .cke_tpl_item
-{
-	border: 2px solid #139FF7;
+.cke_dialog_contents_body .cke_tpl_list a:active .cke_tpl_item {
+	border: 2px solid #139ff7;
 	padding: 6px;
 }

--- a/skins/moono-lexicon/dialog_ie.css
+++ b/skins/moono-lexicon/dialog_ie.css
@@ -11,35 +11,30 @@ This file contains styles to used by all versions of Internet Explorer only.
 */
 
 /* Base it on dialog.css, overriding it with styles defined in this file. */
-@import url("dialog.css");
+@import url('dialog.css');
 
 /* IE doesn't leave enough padding in text input for cursor to blink in RTL. (#6087) */
 .cke_rtl input.cke_dialog_ui_input_text,
 .cke_rtl input.cke_dialog_ui_input_password,
-.cke_rtl input.cke_dialog_ui_input_tel
-{
+.cke_rtl input.cke_dialog_ui_input_tel {
 	padding-right: 2px;
 }
 /* Compensate the padding added above on container. */
 .cke_rtl div.cke_dialog_ui_input_text,
 .cke_rtl div.cke_dialog_ui_input_password,
-.cke_rtl div.cke_dialog_ui_input_tel
-{
+.cke_rtl div.cke_dialog_ui_input_tel {
 	padding-left: 2px;
 }
-.cke_rtl div.cke_dialog_ui_input_text
-{
+.cke_rtl div.cke_dialog_ui_input_text {
 	padding-right: 1px;
 }
 
 .cke_rtl .cke_dialog_ui_vbox_child,
 .cke_rtl .cke_dialog_ui_hbox_child,
 .cke_rtl .cke_dialog_ui_hbox_first,
-.cke_rtl .cke_dialog_ui_hbox_last
-{
+.cke_rtl .cke_dialog_ui_hbox_last {
 	padding-right: 2px !important;
 }
-
 
 /* Disable filters for HC mode. */
 .cke_hc .cke_dialog_title,
@@ -48,9 +43,8 @@ This file contains styles to used by all versions of Internet Explorer only.
 .cke_hc a.cke_dialog_ui_button,
 .cke_hc a.cke_dialog_ui_button:hover,
 .cke_hc a.cke_dialog_ui_button_ok,
-.cke_hc a.cke_dialog_ui_button_ok:hover
-{
-    filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+.cke_hc a.cke_dialog_ui_button_ok:hover {
+	filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
 }
 
 /* 	Remove border from dialog field wrappers in HC
@@ -60,7 +54,6 @@ This file contains styles to used by all versions of Internet Explorer only.
 .cke_hc div.cke_dialog_ui_input_tel,
 .cke_hc div.cke_dialog_ui_input_textarea,
 .cke_hc div.cke_dialog_ui_input_select,
-.cke_hc div.cke_dialog_ui_input_file
-{
+.cke_hc div.cke_dialog_ui_input_file {
 	border: 0;
 }

--- a/skins/moono-lexicon/dialog_ie8.css
+++ b/skins/moono-lexicon/dialog_ie8.css
@@ -11,7 +11,7 @@ This file contains styles to used by Internet Explorer 8 only.
 */
 
 /* Base it on dialog_ie.css, overriding it with styles defined in this file. */
-@import url("dialog_ie.css");
+@import url('dialog_ie.css');
 
 /* Without min-height, border-box is not respected and button shrinks when 2px border on :focus is applied. */
 a.cke_dialog_ui_button {
@@ -21,30 +21,25 @@ a.cke_dialog_ui_button {
 input.cke_dialog_ui_input_text,
 input.cke_dialog_ui_input_password,
 input.cke_dialog_ui_input_tel,
-textarea.cke_dialog_ui_input_textarea
-{
+textarea.cke_dialog_ui_input_textarea {
 	min-height: 18px;
 }
 
 input.cke_dialog_ui_input_text:focus,
 input.cke_dialog_ui_input_password:focus,
 input.cke_dialog_ui_input_tel:focus,
-textarea.cke_dialog_ui_input_textarea:focus
-{
+textarea.cke_dialog_ui_input_textarea:focus {
 	padding-top: 4px;
 	padding-bottom: 2px;
 }
 
-select.cke_dialog_ui_input_select
-{
+select.cke_dialog_ui_input_select {
 	width: 100% !important;
 }
 
-select.cke_dialog_ui_input_select:focus
-{
+select.cke_dialog_ui_input_select:focus {
 	margin-left: 1px;
 	width: 100% !important;
 	padding-top: 2px;
 	padding-bottom: 2px;
-
 }

--- a/skins/moono-lexicon/dialog_iequirks.css
+++ b/skins/moono-lexicon/dialog_iequirks.css
@@ -12,10 +12,9 @@ Quirks mode only.
 */
 
 /* Base it on dialog_ie.css, overriding it with styles defined in this file. */
-@import url("dialog_ie.css");
+@import url('dialog_ie.css');
 
 /* [IE7-8] Filter on footer causes background artifacts when opening dialog. */
-.cke_dialog_footer
-{
-	filter: "";
+.cke_dialog_footer {
+	filter: '';
 }

--- a/skins/moono-lexicon/editor.css
+++ b/skins/moono-lexicon/editor.css
@@ -15,42 +15,41 @@ other files.
 */
 
 /* "Reset" styles, necessary to avoid the editor UI being broken by external CSS. */
-@import url("reset.css");
+@import url('reset.css');
 
 /* Styles the main interface structure (holding box). */
-@import url("mainui.css");
+@import url('mainui.css');
 
 /* Styles all "panels", which are the floating elements that appear when
    opening toolbar combos, menu buttons, context menus, etc. */
-@import url("panel.css");
+@import url('panel.css');
 
 /* Styles the color panel displayed by the color buttons. */
-@import url("colorpanel.css");
+@import url('colorpanel.css');
 
 /* Styles to toolbar. */
-@import url("toolbar.css");
+@import url('toolbar.css');
 
 /* Styles menus, which are lists of selectable items (context menu, menu button). */
-@import url("menu.css");
+@import url('menu.css');
 
 /* Styles toolbar combos. */
-@import url("richcombo.css");
+@import url('richcombo.css');
 
 /* Styles the elements path bar, available at the bottom of the editor UI.*/
-@import url("elementspath.css");
+@import url('elementspath.css');
 
 /* Contains hard-coded presets for "configurable-like" options of the UI
    (e.g. display labels on specific buttons) */
-@import url("presets.css");
+@import url('presets.css');
 
 /* Styles for notifications. */
-@import url("notification.css");
+@import url('notification.css');
 
 /* Important!
    To avoid showing the editor UI while its styles are still not available, the
    editor creates it with visibility:hidden. Here, we restore the UI visibility. */
-.cke_chrome
-{
+.cke_chrome {
 	visibility: inherit;
 }
 
@@ -58,12 +57,10 @@ other files.
    These are usually <span> elements that show not be visible, but that are
    used by screen-readers to announce other elements. Here, we hide these
    <spans>, in fact. */
-.cke_voice_label
-{
+.cke_voice_label {
 	display: none;
 }
 
-legend.cke_voice_label
-{
+legend.cke_voice_label {
 	display: none;
 }

--- a/skins/moono-lexicon/editor_gecko.css
+++ b/skins/moono-lexicon/editor_gecko.css
@@ -11,15 +11,13 @@ This file contains styles to used by all Gecko based browsers (Firefox) only.
 */
 
 /* Base it on editor.css, overriding it with styles defined in this file. */
-@import url("editor.css");
+@import url('editor.css');
 
-.cke_bottom
-{
+.cke_bottom {
 	padding-bottom: 3px;
 }
 
-.cke_combo_text
-{
+.cke_combo_text {
 	margin-bottom: -1px;
 	margin-top: 1px;
 }

--- a/skins/moono-lexicon/editor_ie.css
+++ b/skins/moono-lexicon/editor_ie.css
@@ -11,44 +11,38 @@ This file contains styles to used by all versions of Internet Explorer only.
 */
 
 /* Base it on editor.css, overriding it with styles defined in this file. */
-@import url("editor.css");
+@import url('editor.css');
 
 a.cke_button_disabled,
 
 /* Those two are to overwrite the gradient filter since we cannot have both of them. */
 a.cke_button_disabled:hover,
 a.cke_button_disabled:focus,
-a.cke_button_disabled:active
-{
+a.cke_button_disabled:active {
 	filter: alpha(opacity = 30);
 }
 
 /* PNG Alpha Transparency Fix For IE<9 */
-.cke_button_disabled .cke_button_icon
-{
+.cke_button_disabled .cke_button_icon {
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#00ffffff, endColorstr=#00ffffff);
 }
 
 .cke_button_off:hover,
 .cke_button_off:focus,
-.cke_button_off:active
-{
+.cke_button_off:active {
 	filter: alpha(opacity = 100);
 }
 
 .cke_combo_disabled .cke_combo_inlinelabel,
-.cke_combo_disabled .cke_combo_open
-{
+.cke_combo_disabled .cke_combo_open {
 	filter: alpha(opacity = 30);
 }
 
-.cke_toolbox_collapser
-{
+.cke_toolbox_collapser {
 	border: 1px solid #a6a6a6;
 }
 
-.cke_toolbox_collapser .cke_arrow
-{
+.cke_toolbox_collapser .cke_arrow {
 	margin-top: 1px;
 }
 
@@ -65,7 +59,6 @@ a.cke_button_disabled:active
 .cke_hc a.cke_button_off:active,
 .cke_hc .cke_toolbox_collapser,
 .cke_hc .cke_toolbox_collapser:hover,
-.cke_hc .cke_panel_grouptitle
-{
+.cke_hc .cke_panel_grouptitle {
 	filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
 }

--- a/skins/moono-lexicon/editor_ie8.css
+++ b/skins/moono-lexicon/editor_ie8.css
@@ -11,38 +11,31 @@ This file contains styles to used by Internet Explorer 8 only.
 */
 
 /* Base it on editor_ie.css, overriding it with styles defined in this file. */
-@import url("editor_ie.css");
+@import url('editor_ie.css');
 
-.cke_toolbox_collapser .cke_arrow
-{
-	border-width:4px;
+.cke_toolbox_collapser .cke_arrow {
+	border-width: 4px;
 }
-.cke_toolbox_collapser.cke_toolbox_collapser_min .cke_arrow
-{
-	border-width:3px;
+.cke_toolbox_collapser.cke_toolbox_collapser_min .cke_arrow {
+	border-width: 3px;
 }
-.cke_toolbox_collapser .cke_arrow
-{
+.cke_toolbox_collapser .cke_arrow {
 	margin-top: 0;
 }
 
-
 /* Fix button group separators. Put separator after .cke_toolbar_end
 	element instead of last button in a group. */
-.cke_toolbar
-{
+.cke_toolbar {
 	position: relative;
 }
 
-.cke_rtl .cke_toolbar_end
-{
+.cke_rtl .cke_toolbar_end {
 	right: auto;
 	left: 0;
 }
 
-.cke_toolbar_end:after
-{
-	content: "";
+.cke_toolbar_end:after {
+	content: '';
 	position: absolute;
 	height: 18px;
 	width: 0;
@@ -52,8 +45,7 @@ This file contains styles to used by Internet Explorer 8 only.
 	right: 2px;
 }
 
-.cke_rtl .cke_toolbar_end:after
-{
+.cke_rtl .cke_toolbar_end:after {
 	right: auto;
 	left: 2px;
 }
@@ -71,20 +63,17 @@ This file contains styles to used by Internet Explorer 8 only.
 
 /* Do not show after combo and in the last group. */
 .cke_combo + .cke_toolbar_end:after,
-.cke_toolbar.cke_toolbar_last .cke_toolbar_end:after
-{
+.cke_toolbar.cke_toolbar_last .cke_toolbar_end:after {
 	content: none;
 	border: none;
 }
 
 /* Adjust margins when button is after combo in the same group. */
-.cke_combo + .cke_toolgroup + .cke_toolbar_end:after
-{
+.cke_combo + .cke_toolgroup + .cke_toolbar_end:after {
 	right: 0;
 }
 
-.cke_rtl .cke_combo + .cke_toolgroup + .cke_toolbar_end:after
-{
+.cke_rtl .cke_combo + .cke_toolgroup + .cke_toolbar_end:after {
 	right: auto;
 	left: 0;
 }

--- a/skins/moono-lexicon/editor_iequirks.css
+++ b/skins/moono-lexicon/editor_iequirks.css
@@ -12,17 +12,15 @@ in Quirks mode only.
 */
 
 /* Base it on editor_ie.css, overriding it with styles defined in this file. */
-@import url("editor_ie.css");
+@import url('editor_ie.css');
 
 .cke_top,
 .cke_contents,
-.cke_bottom
-{
+.cke_bottom {
 	width: 100%; /* hasLayout = true */
 }
 
-.cke_button_arrow
-{
+.cke_button_arrow {
 	font-size: 0; /* Set minimal font size, so arrow won't be streched by the text that doesn't exist. */
 }
 
@@ -36,8 +34,7 @@ in Quirks mode only.
 .cke_rtl .cke_combo *,
 .cke_rtl .cke_path_item,
 .cke_rtl .cke_path_item *,
-.cke_rtl .cke_path_empty
-{
+.cke_rtl .cke_path_empty {
 	float: none;
 }
 
@@ -46,34 +43,28 @@ in Quirks mode only.
 .cke_rtl .cke_combo_button,
 .cke_rtl .cke_combo_button *,
 .cke_rtl .cke_button,
-.cke_rtl .cke_button_icon
-{
+.cke_rtl .cke_button_icon {
 	display: inline-block;
 	vertical-align: top;
 }
 
 /* Otherwise formatting toolbar breaks when editing a mixed content (#9893). */
-.cke_rtl .cke_button_icon
-{
+.cke_rtl .cke_button_icon {
 	float: none;
 }
 
-.cke_resizer
-{
+.cke_resizer {
 	width: 10px;
 }
 
-.cke_source
-{
+.cke_source {
 	white-space: normal;
 }
 
-.cke_bottom
-{
+.cke_bottom {
 	position: static; /* Without this bottom space doesn't move when resizing editor. */
 }
 
-.cke_colorbox
-{
+.cke_colorbox {
 	font-size: 0; /* Set minimal font size, so button won't be streched by the text that doesn't exist. */
 }

--- a/skins/moono-lexicon/elementspath.css
+++ b/skins/moono-lexicon/elementspath.css
@@ -19,10 +19,8 @@ The following is a visual representation of its main elements:
 +----------------------------------------------------------------------------+
 */
 
-
 /* The box that holds the entire elements path. */
-.cke_path
-{
+.cke_path {
 	float: left;
 	margin: -2px 0 2px;
 }
@@ -31,8 +29,7 @@ The following is a visual representation of its main elements:
 a.cke_path_item,
 /* Empty element available at the end of the elements path, to help us keeping
    the proper box size when the elements path is empty. */
-span.cke_path_empty
-{
+span.cke_path_empty {
 	display: inline-block;
 	float: left;
 	padding: 3px 4px;
@@ -48,23 +45,20 @@ span.cke_path_empty
 
 .cke_rtl .cke_path,
 .cke_rtl .cke_path_item,
-.cke_rtl .cke_path_empty
-{
+.cke_rtl .cke_path_empty {
 	float: right;
 }
 
 /* The items are <a> elements, so we define its hover states here. */
 a.cke_path_item:hover,
 a.cke_path_item:focus,
-a.cke_path_item:active
-{
+a.cke_path_item:active {
 	background-color: #e5e5e5;
 }
 
 .cke_hc a.cke_path_item:hover,
 .cke_hc a.cke_path_item:focus,
-.cke_hc a.cke_path_item:active
-{
+.cke_hc a.cke_path_item:active {
 	border: 2px solid;
 	padding: 1px 2px;
 }

--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -51,7 +51,6 @@ Special outer level classes used in this file:
 {
 	/* This is <span>, so transform it into a block.*/
 	display: block;
-	border: 1px solid #d1d1d1;
 	padding: 0;
 }
 
@@ -95,9 +94,11 @@ Special outer level classes used in this file:
 
 .cke_top
 {
-	border-bottom: 1px solid #d1d1d1;
-	background: #f8f8f8;
-	padding: 6px 8px 2px;
+	background: white;		/* $white */
+	border: 1px solid #E7E7ED;	/* $secondary-l3 */
+	border-radius: 4px 4px 0 0;
+	border-bottom: none;
+	padding: 6px 7px;
 
 	/* Allow breaking toolbars when in a narrow editor. (#9947) */
 	white-space: normal;
@@ -110,12 +111,13 @@ Special outer level classes used in this file:
 
 .cke_bottom
 {
+	background: white;		/* $white */
+	border: 1px solid #E7E7ED;
+	border-radius: 0 0 4px 4px;
+	border-top: none;
+	color: #6B6C7E;		/* $secondary */
 	padding: 6px 8px 2px;
 	position: relative;
-
-	border-top: 1px solid #d1d1d1;
-
-	background: #f8f8f8;
 }
 
 /* On iOS we need to manually enable scrolling in the contents block. (#9945) */
@@ -193,4 +195,33 @@ Special outer level classes used in this file:
 	outline-style: none;
 
 	box-sizing: border-box;
+}
+
+/* Styles for the editable area */
+.cke_editable
+{
+	background-color: #F1F2F5;	/* $light */
+	height: 100%;
+	margin: 0;
+	padding: 12px 16px 8px 16px;
+	position: absolute;
+	width: 100%;
+}
+
+.cke_editable:after {
+	border: 1px solid #E7E7ED;	/* $secondary-l3 */
+	bottom: 0;
+	content: '';
+	left: 0;
+	position: fixed;
+	right: 0;
+	top: 0;
+}
+
+.cke_editable:focus {
+	background-color: #F0F5FF;	/* $primary-l3 */
+}
+
+.cke_editable:focus:after {
+	border-color: #80ACFF;	/* $primary-l1 */
 }

--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -45,18 +45,15 @@ Special outer level classes used in this file:
 
 */
 
-
 /* The outer boundary of the interface. */
-.cke_chrome
-{
+.cke_chrome {
 	/* This is <span>, so transform it into a block.*/
 	display: block;
 	padding: 0;
 }
 
 /* The inner boundary of the interface. */
-.cke_inner
-{
+.cke_inner {
 	/* This is <span>, so transform it into a block.*/
 	display: block;
 	background: #fff;
@@ -67,14 +64,12 @@ Special outer level classes used in this file:
 
 /* Added to the outer boundary of the UI when in inline editing,
    when the UI is floating. */
-.cke_float
-{
+.cke_float {
 	/* Make white the space between the outer and the inner borders. */
 	border: none;
 }
 
-.cke_float .cke_inner
-{
+.cke_float .cke_inner {
 	/* As we don't have blocks following top (toolbar) we suppress the padding
 	   as the toolbar defines its own margin. */
 	padding-bottom: 0;
@@ -83,8 +78,7 @@ Special outer level classes used in this file:
 /* Make the main spaces enlarge to hold potentially floated content. */
 .cke_top,
 .cke_contents,
-.cke_bottom
-{
+.cke_bottom {
 	/* These are <span>s, so transform them into blocks.*/
 	display: block;
 
@@ -92,10 +86,9 @@ Special outer level classes used in this file:
 	overflow: hidden;
 }
 
-.cke_top
-{
-	background: white;		/* $white */
-	border: 1px solid #E7E7ED;	/* $secondary-l3 */
+.cke_top {
+	background: white; /* $white */
+	border: 1px solid #e7e7ed; /* $secondary-l3 */
 	border-radius: 4px 4px 0 0;
 	border-bottom: none;
 	padding: 6px 7px;
@@ -104,33 +97,29 @@ Special outer level classes used in this file:
 	white-space: normal;
 }
 
-.cke_float .cke_top
-{
+.cke_float .cke_top {
 	border: 1px solid #d1d1d1;
 }
 
-.cke_bottom
-{
-	background: white;		/* $white */
-	border: 1px solid #E7E7ED;
+.cke_bottom {
+	background: white; /* $white */
+	border: 1px solid #e7e7ed;
 	border-radius: 0 0 4px 4px;
 	border-top: none;
-	color: #6B6C7E;		/* $secondary */
+	color: #6b6c7e; /* $secondary */
 	padding: 6px 8px 2px;
 	position: relative;
 }
 
 /* On iOS we need to manually enable scrolling in the contents block. (#9945) */
-.cke_browser_ios .cke_contents
-{
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
+.cke_browser_ios .cke_contents {
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
 }
 
 /* The resizer is the small UI element that is rendered at the bottom right
    part of the editor. It makes is possible to resize the editor UI. */
-.cke_resizer
-{
+.cke_resizer {
 	/* To avoid using images for the resizer, we create a small triangle,
 	   using some CSS magic. */
 	width: 0;
@@ -150,16 +139,14 @@ Special outer level classes used in this file:
 	margin-bottom: 2px;
 }
 
-.cke_hc .cke_resizer
-{
+.cke_hc .cke_resizer {
 	font-size: 15px;
 	width: auto;
 	height: auto;
 	border-width: 0;
 }
 
-.cke_resizer_ltr
-{
+.cke_resizer_ltr {
 	cursor: se-resize;
 
 	float: right;
@@ -170,8 +157,7 @@ Special outer level classes used in this file:
    (usually the .cke_rtl class is used), because it may not necessarily be in
    RTL mode if the main UI is RTL. It depends instead on the context where the
    editor is inserted on. */
-.cke_resizer_rtl
-{
+.cke_resizer_rtl {
 	border-width: 10px 0 0 10px;
 	border-color: transparent transparent transparent #bcbcbc;
 	border-style: dashed dashed dashed solid;
@@ -186,8 +172,7 @@ Special outer level classes used in this file:
 /* The editing area (where users type) can be rendered as an editable <div>
    element (e.g. divarea plugin). In that case, this is the class applied to
    that element. */
-.cke_wysiwyg_div
-{
+.cke_wysiwyg_div {
 	display: block;
 	height: 100%;
 	overflow: auto;
@@ -198,9 +183,8 @@ Special outer level classes used in this file:
 }
 
 /* Styles for the editable area */
-.cke_editable
-{
-	background-color: #F1F2F5;	/* $light */
+.cke_editable {
+	background-color: #f1f2f5; /* $light */
 	height: 100%;
 	margin: 0;
 	padding: 12px 16px 8px 16px;
@@ -209,7 +193,7 @@ Special outer level classes used in this file:
 }
 
 .cke_editable:after {
-	border: 1px solid #E7E7ED;	/* $secondary-l3 */
+	border: 1px solid #e7e7ed; /* $secondary-l3 */
 	bottom: 0;
 	content: '';
 	left: 0;
@@ -219,9 +203,9 @@ Special outer level classes used in this file:
 }
 
 .cke_editable:focus {
-	background-color: #F0F5FF;	/* $primary-l3 */
+	background-color: #f0f5ff; /* $primary-l3 */
 }
 
 .cke_editable:focus:after {
-	border-color: #80ACFF;	/* $primary-l1 */
+	border-color: #80acff; /* $primary-l1 */
 }

--- a/skins/moono-lexicon/menu.css
+++ b/skins/moono-lexicon/menu.css
@@ -58,6 +58,7 @@ Special outer level classes used in this file:
 	/* The "button" inside a menu item is a <a> element.
 	   Transforms it into a block. */
 	display: block;
+	cursor: pointer;
 }
 
 .cke_hc .cke_menubutton
@@ -65,12 +66,11 @@ Special outer level classes used in this file:
 	padding: 2px;
 }
 
-
 .cke_menubutton:hover,
 .cke_menubutton:focus,
 .cke_menubutton:active
 {
-	background-color: #e9e9e9;
+	background-color: #F0F5FF;	/* $primary-l3 */
 	display: block;
 	outline: 1px dotted;
 }
@@ -113,8 +113,7 @@ Special outer level classes used in this file:
 /* The menu item icon. */
 .cke_menubutton_icon
 {
-	background-color: #f8f8f8;
-	padding: 6px 4px;
+	padding: 10px 16px 9px;
 }
 
 .cke_hc .cke_menubutton_icon
@@ -122,13 +121,6 @@ Special outer level classes used in this file:
 	height: 16px;
 	width: 0;
 	padding: 4px 0;
-}
-
-.cke_menubutton:hover .cke_menubutton_icon,
-.cke_menubutton:focus .cke_menubutton_icon,
-.cke_menubutton:active .cke_menubutton_icon
-{
-	background-color: #e9e9e9;
 }
 
 .cke_menubutton_disabled:hover .cke_menubutton_icon,
@@ -164,10 +156,16 @@ Special outer level classes used in this file:
 	vertical-align: middle;
 }
 
+.cke_menubutton_label:not(.cke_menubutton_shortcut)
+{
+	min-width: 64px;
+}
+
 /* Shortcut placed next to the label. */
 .cke_menubutton_shortcut
 {
 	color: #979797;
+	padding: 10px 16px 9px;
 }
 
 .cke_menubutton_disabled .cke_menubutton_label

--- a/skins/moono-lexicon/menu.css
+++ b/skins/moono-lexicon/menu.css
@@ -46,78 +46,65 @@ Special outer level classes used in this file:
 */
 
 /* The .cke_menuitem is the element that holds the entire structure of each of the menu items. */
-.cke_menuitem span
-{
+.cke_menuitem span {
 	/* Avoid the text selection cursor inside menu items. */
 	cursor: default;
 }
 
-
-.cke_menubutton
-{
+.cke_menubutton {
 	/* The "button" inside a menu item is a <a> element.
 	   Transforms it into a block. */
 	display: block;
 	cursor: pointer;
 }
 
-.cke_hc .cke_menubutton
-{
+.cke_hc .cke_menubutton {
 	padding: 2px;
 }
 
 .cke_menubutton:hover,
 .cke_menubutton:focus,
-.cke_menubutton:active
-{
-	background-color: #F0F5FF;	/* $primary-l3 */
+.cke_menubutton:active {
+	background-color: #f0f5ff; /* $primary-l3 */
 	display: block;
 	outline: 1px dotted;
 }
 
-.cke_menubutton:hover
-{
+.cke_menubutton:hover {
 	outline: none;
 }
 
 .cke_hc .cke_menubutton:hover,
 .cke_hc .cke_menubutton:focus,
-.cke_hc .cke_menubutton:active
-{
+.cke_hc .cke_menubutton:active {
 	border: 2px solid;
 	padding: 0;
 }
 
 .cke_menubutton_disabled:hover,
 .cke_menubutton_disabled:focus,
-.cke_menubutton_disabled:active
-{
+.cke_menubutton_disabled:active {
 	/* Do not change background color for disabled items. */
 	background-color: transparent;
 	outline: none;
 }
 
-
-.cke_menubutton_inner
-{
+.cke_menubutton_inner {
 	display: table-row;
 }
 
 .cke_menubutton_icon,
 .cke_menubutton_label,
-.cke_menuarrow
-{
+.cke_menuarrow {
 	display: table-cell;
 }
 
 /* The menu item icon. */
-.cke_menubutton_icon
-{
+.cke_menubutton_icon {
 	padding: 10px 16px 9px;
 }
 
-.cke_hc .cke_menubutton_icon
-{
+.cke_hc .cke_menubutton_icon {
 	height: 16px;
 	width: 0;
 	padding: 4px 0;
@@ -125,95 +112,77 @@ Special outer level classes used in this file:
 
 .cke_menubutton_disabled:hover .cke_menubutton_icon,
 .cke_menubutton_disabled:focus .cke_menubutton_icon,
-.cke_menubutton_disabled:active .cke_menubutton_icon
-{
+.cke_menubutton_disabled:active .cke_menubutton_icon {
 	/* Do not change background color for disabled items. */
 	background-color: #f8f8f8;
 	outline: none;
 }
 
-
-.cke_menuitem .cke_menubutton_on
-{
+.cke_menuitem .cke_menubutton_on {
 	background-color: #e9e9e9;
 	border: 1px solid #dedede;
 	outline: none;
 }
 
-.cke_menubutton_on .cke_menubutton_icon
-{
+.cke_menubutton_on .cke_menubutton_icon {
 	padding-right: 3px;
 	background-color: #e9e9e9;
 }
 
-
 /* The textual part of each menu item. */
-.cke_menubutton_label
-{
+.cke_menubutton_label {
 	padding: 0 5px;
 	background-color: transparent;
 	width: 100%;
 	vertical-align: middle;
 }
 
-.cke_menubutton_label:not(.cke_menubutton_shortcut)
-{
+.cke_menubutton_label:not(.cke_menubutton_shortcut) {
 	min-width: 64px;
 }
 
 /* Shortcut placed next to the label. */
-.cke_menubutton_shortcut
-{
+.cke_menubutton_shortcut {
 	color: #979797;
 	padding: 10px 16px 9px;
 }
 
-.cke_menubutton_disabled .cke_menubutton_label
-{
+.cke_menubutton_disabled .cke_menubutton_label {
 	/* Greyed label text indicates a disabled menu item. */
 	opacity: 0.3;
 	filter: alpha(opacity=30);
 }
 
-.cke_panel_frame .cke_menubutton_label
-{
+.cke_panel_frame .cke_menubutton_label {
 	display: none;
 }
 
-
 /* The separator used to separate menu item groups. */
-.cke_menuseparator
-{
+.cke_menuseparator {
 	background-color: #d1d1d1;
 	height: 1px;
 }
 
-
 /* The small arrow shown for item with sub-menus. */
-.cke_menuarrow
-{
+.cke_menuarrow {
 	background: transparent url(images/arrow.png) no-repeat 0 10px;
 	padding: 0 5px;
 }
 
-.cke_rtl .cke_menuarrow
-{
+.cke_rtl .cke_menuarrow {
 	background-position: 5px -13px;
 	background-repeat: no-repeat;
 }
 
-.cke_hc .cke_menuarrow
-{
+.cke_hc .cke_menuarrow {
 	background-image: none;
 }
 
-.cke_menuarrow span
-{
+.cke_menuarrow span {
 	display: none;
 }
 
-.cke_hc .cke_menuarrow span
-{
+.cke_hc .cke_menuarrow span {
 	vertical-align: middle;
 	display: inline;
 }

--- a/skins/moono-lexicon/notification.css
+++ b/skins/moono-lexicon/notification.css
@@ -44,13 +44,11 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  * Success and info notifications have the same structure as warning, but use
  * `cke_notification_success` and `cke_notification_info` instead of `cke_notification_warning`.
  */
-.cke_notifications_area
-{
+.cke_notifications_area {
 	/* Prevent notification margin capture clicking. */
 	pointer-events: none;
 }
-.cke_notification
-{
+.cke_notification {
 	pointer-events: auto;
 	position: relative;
 	margin: 10px;
@@ -64,44 +62,45 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	animation: fadeIn 0.7s;
 }
 
-.cke_notification_message a
-{
-	color: #12306F;
+.cke_notification_message a {
+	color: #12306f;
 }
 
-@-webkit-keyframes fadeIn
-{
-	from { opacity: 0.4; }
-	to { opacity: 0.95; }
+@-webkit-keyframes fadeIn {
+	from {
+		opacity: 0.4;
+	}
+	to {
+		opacity: 0.95;
+	}
 }
 
-@keyframes fadeIn
-{
-	from { opacity: 0.4; }
-	to { opacity: 0.95; }
+@keyframes fadeIn {
+	from {
+		opacity: 0.4;
+	}
+	to {
+		opacity: 0.95;
+	}
 }
 
-.cke_notification_success
-{
-	background: #72B572;
-	border: 1px solid #63A563;
+.cke_notification_success {
+	background: #72b572;
+	border: 1px solid #63a563;
 }
 
-.cke_notification_warning
-{
-	background: #C83939;
-	border: 1px solid #902B2B;
+.cke_notification_warning {
+	background: #c83939;
+	border: 1px solid #902b2b;
 }
 
-.cke_notification_info
-{
-	background: #2E9AD0;
-	border: 1px solid #0F74A8;
+.cke_notification_info {
+	background: #2e9ad0;
+	border: 1px solid #0f74a8;
 }
 
-.cke_notification_info span.cke_notification_progress
-{
-	background-color: #0F74A8;
+.cke_notification_info span.cke_notification_progress {
+	background-color: #0f74a8;
 	display: block;
 	padding: 0;
 	margin: 0;
@@ -111,8 +110,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	z-index: 1;
 }
 
-.cke_notification_message
-{
+.cke_notification_message {
 	position: relative;
 	margin: 4px 23px 3px;
 	font-family: Arial, Helvetica, sans-serif;
@@ -123,8 +121,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	overflow: hidden;
 }
 
-.cke_notification_close
-{
+.cke_notification_close {
 	background-image: url(images/close.png);
 	background-repeat: no-repeat;
 	background-position: 50%;
@@ -142,25 +139,21 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	filter: alpha(opacity = 60);
 }
 
-.cke_notification_close:hover
-{
+.cke_notification_close:hover {
 	opacity: 1;
 	filter: alpha(opacity = 100);
 }
 
-.cke_notification_close span
-{
+.cke_notification_close span {
 	display: none;
 }
 
-.cke_notification_warning a.cke_notification_close
-{
+.cke_notification_warning a.cke_notification_close {
 	opacity: 0.8;
 	filter: alpha(opacity = 80);
 }
 
-.cke_notification_warning a.cke_notification_close:hover
-{
+.cke_notification_warning a.cke_notification_close:hover {
 	opacity: 1;
 	filter: alpha(opacity = 100);
 }

--- a/skins/moono-lexicon/panel.css
+++ b/skins/moono-lexicon/panel.css
@@ -40,24 +40,21 @@ This file also defines styles for panel lists (used by combos). For menu-like
 panel contents and color panels check menu.css and colorpanel.css.
 */
 
-
 /* The box that holds an IFRAME. It's inserted into a host document and positioned
    absolutely by the application. It floats above the host document/editor. */
-.cke_panel
-{
+.cke_panel {
 	/* Restore the loading hide */
 	visibility: visible;
-    width: 120px;
-   	height: 100px;
-   	overflow: hidden;
+	width: 120px;
+	height: 100px;
+	overflow: hidden;
 
 	background-color: #fff;
-    border: 1px solid #d1d1d1;
+	border: 1px solid #d1d1d1;
 }
 
 /* This class represents panels which are used as context menus. */
-.cke_menu_panel
-{
+.cke_menu_panel {
 	border: none;
 	border-radius: 4px;
 	box-shadow: 0px 4px 8px rgba(39, 40, 51, 0.12);
@@ -66,15 +63,13 @@ panel contents and color panels check menu.css and colorpanel.css.
 }
 
 /* This class represents panels which are used by rich combos. */
-.cke_combopanel
-{
-    width: 150px;
-    height: 170px;
+.cke_combopanel {
+	width: 150px;
+	height: 170px;
 }
 
 /* The IFRAME the panel is wrapped into. */
-.cke_panel_frame
-{
+.cke_panel_frame {
 	width: 100%;
 	height: 100%;
 	font-size: 12px;
@@ -84,15 +79,13 @@ panel contents and color panels check menu.css and colorpanel.css.
 }
 
 /* The HTML document which is a direct descendant of the IFRAME */
-.cke_panel_container
-{
+.cke_panel_container {
 	overflow-y: auto;
 	overflow-x: hidden;
 }
 
 /* Remove focus outline. The .cke_panel_block gets focused after combo without any active item is selected. */
-.cke_panel_block:focus
-{
+.cke_panel_block:focus {
 	outline: none;
 }
 
@@ -124,10 +117,8 @@ is its visual representation:
 +-------------------------------------+
 */
 
-
 /* The list of panel items. */
-.cke_panel_list
-{
+.cke_panel_list {
 	margin: 0;
 	padding: 0;
 	list-style-type: none;
@@ -135,16 +126,14 @@ is its visual representation:
 }
 
 /* The item of .cke_panel_list */
-.cke_panel_listItem
-{
+.cke_panel_listItem {
 	margin: 0;
 	padding: 0;
 }
 
 /* The child of .cke_panel_listItem. These elements contain spans which are
    to display a real name of the property which is visible for an end-user. */
-.cke_panel_listItem a
-{
+.cke_panel_listItem a {
 	padding: 6px 7px;
 	display: block;
 	color: inherit !important;
@@ -153,29 +142,25 @@ is its visual representation:
 	text-overflow: ellipsis;
 }
 
-.cke_hc .cke_panel_listItem a
-{
+.cke_hc .cke_panel_listItem a {
 	border-style: none;
 }
 
 .cke_panel_listItem.cke_selected a,
 .cke_panel_listItem a:hover,
 .cke_panel_listItem a:focus,
-.cke_panel_listItem a:active
-{
+.cke_panel_listItem a:active {
 	background-color: #e9e9e9;
 }
 
 /* Redefine focus outline so it is the same for all browsers. */
-.cke_panel_listItem a:focus
-{
+.cke_panel_listItem a:focus {
 	outline: 1px dotted #000;
 }
 
 .cke_hc .cke_panel_listItem a:hover,
 .cke_hc .cke_panel_listItem a:focus,
-.cke_hc .cke_panel_listItem a:active
-{
+.cke_hc .cke_panel_listItem a:active {
 	border: 2px solid;
 	padding: 4px 5px;
 }
@@ -189,15 +174,13 @@ is its visual representation:
 .cke_panel_listItem h4,
 .cke_panel_listItem h5,
 .cke_panel_listItem h6,
-.cke_panel_listItem pre
-{
+.cke_panel_listItem pre {
 	margin-top: 0px;
 	margin-bottom: 0px;
 }
 
 /* The title of the entire panel which is visible on top of the list. */
-.cke_panel_grouptitle
-{
+.cke_panel_grouptitle {
 	cursor: default;
 	font-size: 11px;
 	font-weight: bold;

--- a/skins/moono-lexicon/panel.css
+++ b/skins/moono-lexicon/panel.css
@@ -58,6 +58,9 @@ panel contents and color panels check menu.css and colorpanel.css.
 /* This class represents panels which are used as context menus. */
 .cke_menu_panel
 {
+	border: none;
+	border-radius: 4px;
+	box-shadow: 0px 4px 8px rgba(39, 40, 51, 0.12);
 	padding: 0;
 	margin: 0;
 }

--- a/skins/moono-lexicon/presets.css
+++ b/skins/moono-lexicon/presets.css
@@ -5,20 +5,17 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 /* "Source" button label */
 .cke_button__source_label,
-.cke_button__sourcedialog_label
-{
+.cke_button__sourcedialog_label {
 	display: inline;
 }
 
 /* "Font Size" panel size */
-.cke_combopanel__fontsize
-{
+.cke_combopanel__fontsize {
 	width: 135px;
 }
 
 /* Editable regions */
-textarea.cke_source
-{
+textarea.cke_source {
 	font-family: 'Courier New', Monospace;
 	font-size: small;
 	background-color: #fff;
@@ -29,7 +26,7 @@ textarea.cke_source
 	display: block;
 }
 
-.cke_wysiwyg_frame, .cke_wysiwyg_div
-{
+.cke_wysiwyg_frame,
+.cke_wysiwyg_div {
 	background-color: #fff;
 }

--- a/skins/moono-lexicon/reset.css
+++ b/skins/moono-lexicon/reset.css
@@ -24,8 +24,7 @@ https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 */
 
 /* Reset for single elements, not their children. */
-.cke_reset
-{
+.cke_reset {
 	/* Do not include inheritable rules here. */
 	margin: 0;
 	padding: 0;
@@ -41,9 +40,10 @@ https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 }
 
 /* Reset for elements and their children. */
-.cke_reset_all, .cke_reset_all *,
-.cke_reset_all a, .cke_reset_all textarea
-{
+.cke_reset_all,
+.cke_reset_all *,
+.cke_reset_all a,
+.cke_reset_all textarea {
 	/* The following must be identical to .cke_reset. */
 	margin: 0;
 	padding: 0;
@@ -59,7 +59,8 @@ https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 
 	/* These are rule inherited by all children elements. */
 	border-collapse: collapse;
-	font: normal normal normal 12px Arial,Helvetica,Tahoma,Verdana,Sans-Serif;
+	font: normal normal normal 12px Arial, Helvetica, Tahoma, Verdana,
+		Sans-Serif;
 	color: #000;
 	text-align: left;
 	white-space: nowrap;
@@ -67,49 +68,41 @@ https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 	float: none;
 }
 
-.cke_reset_all .cke_rtl *
-{
+.cke_reset_all .cke_rtl * {
 	text-align: right;
 }
 
 /* Defaults for some elements. */
 
-.cke_reset_all iframe
-{
-	vertical-align: inherit;	/** For IE */
+.cke_reset_all iframe {
+	vertical-align: inherit; /** For IE */
 }
 
-.cke_reset_all textarea
-{
+.cke_reset_all textarea {
 	white-space: pre-wrap;
 }
 
 .cke_reset_all textarea,
-.cke_reset_all input[type="text"],
-.cke_reset_all input[type="password"]
-{
+.cke_reset_all input[type='text'],
+.cke_reset_all input[type='password'] {
 	cursor: text;
 }
 
 .cke_reset_all textarea[disabled],
-.cke_reset_all input[type="text"][disabled],
-.cke_reset_all input[type="password"][disabled]
-{
+.cke_reset_all input[type='text'][disabled],
+.cke_reset_all input[type='password'][disabled] {
 	cursor: default;
 }
 
-.cke_reset_all fieldset
-{
+.cke_reset_all fieldset {
 	padding: 10px;
-	border: 2px groove #E0DFE3;
+	border: 2px groove #e0dfe3;
 }
 
-.cke_reset_all select
-{
+.cke_reset_all select {
 	box-sizing: border-box;
 }
 
-.cke_reset_all table
-{
+.cke_reset_all table {
 	table-layout: auto;
 }

--- a/skins/moono-lexicon/richcombo.css
+++ b/skins/moono-lexicon/richcombo.css
@@ -24,33 +24,27 @@ The visual representation of a rich combo widget looks as follows:
 +-----------------------------------------------------------------------------------+
 */
 
-
 /* The box that hold the entire combo widget */
-.cke_combo
-{
+.cke_combo {
 	display: inline-block;
 	float: left;
 	position: relative;
 	margin-bottom: 5px;
 }
 
-.cke_rtl .cke_combo
-{
+.cke_rtl .cke_combo {
 	float: right;
 }
 
-.cke_hc .cke_combo
-{
+.cke_hc .cke_combo {
 	margin-top: 1px;
 	margin-bottom: 10px;
 }
 
-
 /* Combo separators. */
 /* Separators after every combo. */
-.cke_combo:after
-{
-	content: "";
+.cke_combo:after {
+	content: '';
 	position: absolute;
 	height: 18px;
 	width: 0;
@@ -60,24 +54,20 @@ The visual representation of a rich combo widget looks as follows:
 	right: 0;
 }
 
-.cke_rtl .cke_combo:after
-{
+.cke_rtl .cke_combo:after {
 	border-right: 0;
 	border-left: 1px solid #bcbcbc;
 	right: auto;
 	left: 0;
 }
 
-.cke_hc .cke_combo:after
-{
+.cke_hc .cke_combo:after {
 	border-color: #000;
 }
 
-
 /* Combo button. */
 /* The container for combo text and arrow. */
-a.cke_combo_button
-{
+a.cke_combo_button {
 	cursor: default;
 	display: inline-block;
 	float: left;
@@ -85,23 +75,19 @@ a.cke_combo_button
 	padding: 1px;
 }
 
-.cke_rtl a.cke_combo_button
-{
+.cke_rtl a.cke_combo_button {
 	float: right;
 }
 
-.cke_hc a.cke_combo_button
-{
+.cke_hc a.cke_combo_button {
 	padding: 4px;
 }
-
 
 /* Combo states. */
 .cke_combo_on a.cke_combo_button,
 .cke_combo_off a.cke_combo_button:hover,
 .cke_combo_off a.cke_combo_button:focus,
-.cke_combo_off a.cke_combo_button:active
-{
+.cke_combo_off a.cke_combo_button:active {
 	background: #e5e5e5;
 	border: 1px solid #bcbcbc;
 	/* Move combo so borders cover separators. Adjust padding to borders. */
@@ -113,19 +99,15 @@ a.cke_combo_button
 	outline: none;
 }
 
-
-
 .cke_combo_on a.cke_combo_button,
-.cke_combo_off a.cke_combo_button:active
-{
+.cke_combo_off a.cke_combo_button:active {
 	background: #fff;
 }
 
 .cke_rtl .cke_combo_on a.cke_combo_button,
 .cke_rtl .cke_combo_off a.cke_combo_button:hover,
 .cke_rtl .cke_combo_off a.cke_combo_button:focus,
-.cke_rtl .cke_combo_off a.cke_combo_button:active
-{
+.cke_rtl .cke_combo_off a.cke_combo_button:active {
 	/* Move combo so borders cover separators. Adjust padding to borders. */
 	padding: 0 1px 0 0;
 	margin-left: 0;
@@ -135,8 +117,7 @@ a.cke_combo_button
 .cke_hc .cke_combo_on a.cke_combo_button,
 .cke_hc .cke_combo_off a.cke_combo_button:hover,
 .cke_hc .cke_combo_off a.cke_combo_button:focus,
-.cke_hc .cke_combo_off a.cke_combo_button:active
-{
+.cke_hc .cke_combo_off a.cke_combo_button:active {
 	border: 3px solid #000;
 	padding: 1px 1px 1px 2px;
 }
@@ -144,18 +125,15 @@ a.cke_combo_button
 .cke_hc.cke_rtl .cke_combo_on a.cke_combo_button,
 .cke_hc.cke_rtl .cke_combo_off a.cke_combo_button:hover,
 .cke_hc.cke_rtl .cke_combo_off a.cke_combo_button:focus,
-.cke_hc.cke_rtl .cke_combo_off a.cke_combo_button:active
-{
+.cke_hc.cke_rtl .cke_combo_off a.cke_combo_button:active {
 	padding: 1px 2px 1px 1px;
 }
-
 
 /* First combo in a group. */
 .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
 .cke_toolbar_start + .cke_combo_off a.cke_combo_button:hover,
 .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
-.cke_toolbar_start + .cke_combo_off a.cke_combo_button:active
-{
+.cke_toolbar_start + .cke_combo_off a.cke_combo_button:active {
 	/* Move first combo so borders cover separators. Adjust padding to borders. */
 	padding: 0 0 0 3px;
 	margin-left: -3px;
@@ -164,8 +142,7 @@ a.cke_combo_button
 .cke_rtl .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
 .cke_rtl .cke_toolbar_start + .cke_combo_off a.cke_combo_button:hover,
 .cke_rtl .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
-.cke_rtl .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active
-{
+.cke_rtl .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active {
 	/* Move first combo so borders cover separators. Adjust padding to borders. */
 	padding: 0 3px 0 0;
 	margin-left: 0;
@@ -173,26 +150,51 @@ a.cke_combo_button
 }
 
 .cke_hc .cke_toolbar > .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
-.cke_hc .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:hover,
-.cke_hc .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
-.cke_hc .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active
-{
+.cke_hc
+	.cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:hover,
+.cke_hc
+	.cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:focus,
+.cke_hc
+	.cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:active {
 	/* Move first combo so borders cover separators. Adjust padding to borders. */
 	padding: 1px 1px 1px 7px;
 	margin-left: -6px;
 }
 
-.cke_hc.cke_rtl .cke_toolbar > .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
-.cke_hc.cke_rtl .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:hover,
-.cke_hc.cke_rtl .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
-.cke_hc.cke_rtl .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active
-{
+.cke_hc.cke_rtl
+	.cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_on
+	a.cke_combo_button,
+.cke_hc.cke_rtl
+	.cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:hover,
+.cke_hc.cke_rtl
+	.cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:focus,
+.cke_hc.cke_rtl
+	.cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:active {
 	/* Move first combo so borders cover separators. Adjust padding to borders. */
 	padding: 1px 7px 1px 1px;
 	margin-left: 0;
 	margin-right: -6px;
 }
-
 
 /* First combo in a toolbar. */
 .cke_toolbox .cke_toolbar:first-child > .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
@@ -203,73 +205,102 @@ a.cke_combo_button
 .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
 .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:hover,
 .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
-.cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active
-{
+.cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active {
 	/* If first combo in a row do not use negative margin so it is aligned with other rows on hover. */
 	padding: 0;
 	margin: 0;
 }
 
-.cke_hc .cke_toolbox .cke_toolbar:first-child > .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
-.cke_hc .cke_toolbox .cke_toolbar:first-child > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:hover,
-.cke_hc .cke_toolbox .cke_toolbar:first-child > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
-.cke_hc .cke_toolbox .cke_toolbar:first-child > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active,
-.cke_hc .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_on a.cke_combo_button,
-.cke_hc .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:hover,
-.cke_hc .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
-.cke_hc .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active
-{
+.cke_hc
+	.cke_toolbox
+	.cke_toolbar:first-child
+	> .cke_toolbar_start
+	+ .cke_combo_on
+	a.cke_combo_button,
+.cke_hc
+	.cke_toolbox
+	.cke_toolbar:first-child
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:hover,
+.cke_hc
+	.cke_toolbox
+	.cke_toolbar:first-child
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:focus,
+.cke_hc
+	.cke_toolbox
+	.cke_toolbar:first-child
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:active,
+.cke_hc
+	.cke_toolbar_break
+	+ .cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_on
+	a.cke_combo_button,
+.cke_hc
+	.cke_toolbar_break
+	+ .cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:hover,
+.cke_hc
+	.cke_toolbar_break
+	+ .cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:focus,
+.cke_hc
+	.cke_toolbar_break
+	+ .cke_toolbar
+	> .cke_toolbar_start
+	+ .cke_combo_off
+	a.cke_combo_button:active {
 	/* If first combo in a row do not use negative margin so it is aligned with other rows on hover. */
 	padding: 1px;
 	margin: 0;
 }
 
-
 /* Add Margin after last combo to keep next .cke_toolgroup same distance as in every other case. */
 .cke_toolbar .cke_combo + .cke_toolbar_end,
-.cke_toolbar .cke_combo + .cke_toolgroup
-{
+.cke_toolbar .cke_combo + .cke_toolgroup {
 	margin-right: 0;
 	margin-left: 2px;
 }
 
 .cke_rtl .cke_toolbar .cke_combo + .cke_toolbar_end,
-.cke_rtl .cke_toolbar .cke_combo + .cke_toolgroup
-{
+.cke_rtl .cke_toolbar .cke_combo + .cke_toolgroup {
 	margin-left: 0;
 	margin-right: 2px;
 }
 
 .cke_hc .cke_toolbar .cke_combo + .cke_toolbar_end,
-.cke_hc .cke_toolbar .cke_combo + .cke_toolgroup
-{
+.cke_hc .cke_toolbar .cke_combo + .cke_toolgroup {
 	margin-left: 5px;
 }
 
 .cke_hc.cke_rtl .cke_toolbar .cke_combo + .cke_toolbar_end,
-.cke_hc.cke_rtl .cke_toolbar .cke_combo + .cke_toolgroup
-{
+.cke_hc.cke_rtl .cke_toolbar .cke_combo + .cke_toolgroup {
 	margin-left: 0;
 	margin-right: 5px;
 }
 
-
 /* No separator after last combo in a row. */
-.cke_toolbar.cke_toolbar_last .cke_combo:nth-last-child(-n + 2):after
-{
+.cke_toolbar.cke_toolbar_last .cke_combo:nth-last-child(-n + 2):after {
 	content: none;
 	border: none;
 	width: 0;
 	height: 0;
 }
 
-
 /* Combo inner elements. */
 /* The label that shows the current value of the rich combo.
    By default, it holds the name of the property.
    See: .cke_combo_inlinelabel */
-.cke_combo_text
-{
+.cke_combo_text {
 	line-height: 26px;
 	padding-left: 10px;
 	text-overflow: ellipsis;
@@ -277,27 +308,24 @@ a.cke_combo_button
 	float: left;
 	cursor: default;
 	color: #484848;
-    width: 60px;
+	width: 60px;
 }
 
-.cke_rtl .cke_combo_text
-{
+.cke_rtl .cke_combo_text {
 	float: right;
 	text-align: right;
 	padding-left: 0;
 	padding-right: 10px;
 }
 
-.cke_hc .cke_combo_text
-{
+.cke_hc .cke_combo_text {
 	line-height: 18px;
 	font-size: 12px;
 }
 
 /* The handler which opens the panel of rich combo properties.
    It holds an arrow as a visual indicator. */
-.cke_combo_open
-{
+.cke_combo_open {
 	cursor: default;
 	display: inline-block;
 	font-size: 0;
@@ -307,14 +335,12 @@ a.cke_combo_button
 	width: 5px;
 }
 
-.cke_hc .cke_combo_open
-{
+.cke_hc .cke_combo_open {
 	height: 12px;
 }
 
 /* The arrow which is displayed inside of the .cke_combo_open handler. */
-.cke_combo_arrow
-{
+.cke_combo_arrow {
 	cursor: default;
 	margin: 11px 0 0;
 	float: left;
@@ -328,8 +354,7 @@ a.cke_combo_button
 	border-top: 3px solid #484848;
 }
 
-.cke_hc .cke_combo_arrow
-{
+.cke_hc .cke_combo_arrow {
 	font-size: 10px;
 	width: auto;
 	border: 0;
@@ -338,8 +363,7 @@ a.cke_combo_button
 
 /* The label of the combo widget. It is invisible by default, yet
    it's important for semantics and accessibility. */
-.cke_combo_label
-{
+.cke_combo_label {
 	display: none;
 	float: left;
 	line-height: 26px;
@@ -347,8 +371,7 @@ a.cke_combo_button
 	margin-right: 5px;
 }
 
-.cke_rtl .cke_combo_label
-{
+.cke_rtl .cke_combo_label {
 	float: right;
 	margin-left: 5px;
 	margin-right: 0;
@@ -356,7 +379,6 @@ a.cke_combo_button
 
 /* Disabled combo button styles. */
 .cke_combo_disabled .cke_combo_inlinelabel,
-.cke_combo_disabled .cke_combo_open
-{
+.cke_combo_disabled .cke_combo_open {
 	opacity: 0.3;
 }

--- a/skins/moono-lexicon/toolbar.css
+++ b/skins/moono-lexicon/toolbar.css
@@ -67,7 +67,7 @@ Special outer level classes used in this file:
 {
 	border: 0;
 	float: left;
-	margin: 1px 2px 6px 0;
+	margin: 1px 4px 6px 0;
 	/* Helps to set proper position for separators after .cke_button. */
 	padding-right: 3px;
 }
@@ -97,19 +97,16 @@ Special outer level classes used in this file:
 /* A toolbar button . */
 a.cke_button
 {
+	border-radius: 4px;
 	display: inline-block;
-	height: 18px;
-	padding: 4px 6px;
+	height: 16px;
+	padding: 6px;
 	outline: none;
 	cursor: default;
 	float: left;
-	border: 0;
+	border: 2px solid transparent;
 	position: relative;
-}
-
-/* #2483 */
-a.cke_button_expandable {
-	padding: 4px 5px;
+	margin: 0 1px;
 }
 
 .cke_rtl a.cke_button
@@ -136,35 +133,24 @@ a.cke_button_expandable {
    i.e. currently writing in bold or when spell checking is enabled. */
 a.cke_button_on
 {
-	background: #fff;
-	border: 1px #bcbcbc solid;
-	padding: 3px 5px;
+	background-color: rgba(39, 40, 51, 0.06);	/* $dark 0.06 */
 }
-
-/* #2483 */
-a.cke_button_expandable.cke_button_on
-{
-	padding: 3px 4px;
-}
-
 
 /* Button states. */
-a.cke_button_off:hover,
-a.cke_button_off:focus,
-a.cke_button_off:active
+a.cke_button:hover
 {
-	background: #e5e5e5;
-	border: 1px #bcbcbc solid;
-	/* Compensate the border change */
-	padding: 3px 5px;
+	cursor: pointer;
 }
 
-/* Expandable button states (#2483). */
-a.cke_button_expandable.cke_button_off:hover,
-a.cke_button_expandable.cke_button_off:focus,
-a.cke_button_expandable.cke_button_off:active
+a.cke_button:focus
 {
-	padding: 3px 4px;
+	border-color: #80ACFF;		/* $primaryl-l1 */
+}
+
+a.cke_button_off:hover,
+a.cke_button_off:active
+{
+	background-color: rgba(39, 40, 51, 0.04);	/* $dark 0.04 */
 }
 
 .cke_hc a.cke_button_on,
@@ -178,32 +164,13 @@ a.cke_button_expandable.cke_button_off:active
 	padding: 1px 3px;
 }
 
-
-/* Disabled Button states. */
-a.cke_button_disabled:hover,
-a.cke_button_disabled:focus,
-a.cke_button_disabled:active
-{
-	border: 0;
-	padding: 4px 6px;
-	background-color: transparent;
-}
-
-/* Expandable disabled Button states (#2483). */
-a.cke_button_expandable.cke_button_disabled:hover,
-a.cke_button_expandable.cke_button_disabled:active
-{
-	padding: 4px 5px;
+a.cke_button_disabled:hover {
+	cursor: default;
 }
 
 a.cke_button_disabled:focus {
 	border: 1px #bcbcbc solid;
 	padding: 3px 5px;
-}
-
-/* #2483 */
-a.cke_button_expandable.cke_button_disabled:focus {
-	padding: 3px 4px;
 }
 
 .cke_hc a.cke_button_disabled:hover,
@@ -258,12 +225,12 @@ a.cke_button_disabled .cke_button_arrow
 {
 	content: "";
 	position: absolute;
-	height: 18px;
+	height: 24px;
 	width: 0;
-	border-right: 1px solid #bcbcbc;
-	margin-top: 4px;
+	border-right: 1px solid #E7E7ED;	/* $secondary-l3 */
+	margin-top: 2px;
 	top: 0;
-	right: -3px;
+	right: -7px;
 }
 
 .cke_rtl .cke_toolgroup a.cke_button:last-child:after,
@@ -293,15 +260,6 @@ a.cke_button_disabled .cke_button_arrow
 	top: 0;
 	right: auto;
 	left: -7px;
-}
-
-/* Adjust separator position on button hover. */
-.cke_toolgroup a.cke_button:hover:last-child:after,
-.cke_toolgroup a.cke_button:focus:last-child:after,
-.cke_toolgroup a.cke_button.cke_button_on:last-child:after
-{
-	top: -1px;
-	right: -4px;
 }
 
 .cke_rtl .cke_toolgroup a.cke_button:hover:last-child:after,
@@ -344,7 +302,6 @@ a.cke_button_disabled .cke_button_arrow
 {
 	cursor: inherit;
 	background-repeat: no-repeat;
-	margin-top: 1px;
 	width: 16px;
 	height: 16px;
 	float: left;
@@ -424,9 +381,9 @@ a.cke_button_disabled .cke_button_arrow
 .cke_toolbar_separator
 {
 	float: left;
-	background-color: #bcbcbc;
-	margin: 4px 2px 0 2px;
-	height: 18px;
+	background-color: #E7E7ED;	/* $secondary-l3 */
+	margin: 4px 3px 0 3px;
+	height: 24px;
 	width: 1px;
 }
 

--- a/skins/moono-lexicon/toolbar.css
+++ b/skins/moono-lexicon/toolbar.css
@@ -49,22 +49,17 @@ Special outer level classes used in this file:
 	.cke_rtl: Available when the editor UI is on RTL.
 */
 
-
 /* The box that holds each toolbar. */
-.cke_toolbar
-{
+.cke_toolbar {
 	float: left;
 }
 
-.cke_rtl .cke_toolbar
-{
+.cke_rtl .cke_toolbar {
 	float: right;
 }
 
-
 /* The box that holds buttons. */
-.cke_toolgroup
-{
+.cke_toolgroup {
 	border: 0;
 	float: left;
 	margin: 1px 4px 6px 0;
@@ -72,8 +67,7 @@ Special outer level classes used in this file:
 	padding-right: 3px;
 }
 
-.cke_rtl .cke_toolgroup
-{
+.cke_rtl .cke_toolgroup {
 	float: right;
 	margin: 1px 0 6px 2px;
 	/* Helps to set proper position for separators after .cke_button. */
@@ -81,22 +75,18 @@ Special outer level classes used in this file:
 	padding-right: 0;
 }
 
-.cke_hc .cke_toolgroup
-{
+.cke_hc .cke_toolgroup {
 	margin-right: 5px;
 	margin-bottom: 5px;
 }
 
-.cke_hc.cke_rtl .cke_toolgroup
-{
+.cke_hc.cke_rtl .cke_toolgroup {
 	margin-right: 0;
 	margin-left: 5px;
 }
 
-
 /* A toolbar button . */
-a.cke_button
-{
+a.cke_button {
 	border-radius: 4px;
 	display: inline-block;
 	height: 16px;
@@ -109,55 +99,46 @@ a.cke_button
 	margin: 0 1px;
 }
 
-.cke_rtl a.cke_button
-{
+.cke_rtl a.cke_button {
 	float: right;
 }
 
-.cke_hc a.cke_button
-{
+.cke_hc a.cke_button {
 	border: 1px solid black;
 	/* Compensate the added border */
 	padding: 3px 5px;
 	margin: 0 3px 5px 0;
 }
 
-.cke_hc.cke_rtl a.cke_button
-{
+.cke_hc.cke_rtl a.cke_button {
 	margin: 0 0 5px 3px;
 }
-
 
 /* This class is applied to the button when it is "active" (pushed).
    This style indicates that the feature associated with the button is active
    i.e. currently writing in bold or when spell checking is enabled. */
-a.cke_button_on
-{
-	background-color: rgba(39, 40, 51, 0.06);	/* $dark 0.06 */
+a.cke_button_on {
+	background-color: rgba(39, 40, 51, 0.06); /* $dark 0.06 */
 }
 
 /* Button states. */
-a.cke_button:hover
-{
+a.cke_button:hover {
 	cursor: pointer;
 }
 
-a.cke_button:focus
-{
-	border-color: #80ACFF;		/* $primaryl-l1 */
+a.cke_button:focus {
+	border-color: #80acff; /* $primaryl-l1 */
 }
 
 a.cke_button_off:hover,
-a.cke_button_off:active
-{
-	background-color: rgba(39, 40, 51, 0.04);	/* $dark 0.04 */
+a.cke_button_off:active {
+	background-color: rgba(39, 40, 51, 0.04); /* $dark 0.04 */
 }
 
 .cke_hc a.cke_button_on,
 .cke_hc a.cke_button_off:hover,
 .cke_hc a.cke_button_off:focus,
-.cke_hc a.cke_button_off:active
-{
+.cke_hc a.cke_button_off:active {
 	background: #e5e5e5;
 	border: 3px solid #000;
 	/* Compensate the border change */
@@ -175,8 +156,7 @@ a.cke_button_disabled:focus {
 
 .cke_hc a.cke_button_disabled:hover,
 .cke_hc a.cke_button_disabled:focus,
-.cke_hc a.cke_button_disabled:active
-{
+.cke_hc a.cke_button_disabled:active {
 	border: 1px solid #acacac;
 	padding: 3px 5px;
 	margin: 0 3px 5px 0;
@@ -190,52 +170,46 @@ a.cke_button_disabled:focus {
 
 .cke_hc.cke_rtl a.cke_button_disabled:hover,
 .cke_hc.cke_rtl a.cke_button_disabled:focus,
-.cke_hc.cke_rtl a.cke_button_disabled:active
-{
+.cke_hc.cke_rtl a.cke_button_disabled:active {
 	margin: 0 0 5px 3px;
 }
-
 
 /* Disabled button. */
 /* This class is applied to the button when the feature associated with the
    button cannot be used (grayed-out), i.e. paste button remains disabled when
    there is nothing in the clipboard to be pasted. */
 a.cke_button_disabled .cke_button_icon,
-a.cke_button_disabled .cke_button_arrow
-{
+a.cke_button_disabled .cke_button_arrow {
 	opacity: 0.3;
 }
 
-.cke_hc a.cke_button_disabled
-{
+.cke_hc a.cke_button_disabled {
 	border-color: #acacac;
 }
 
 .cke_hc a.cke_button_disabled .cke_button_icon,
-.cke_hc a.cke_button_disabled .cke_button_label
-{
+.cke_hc a.cke_button_disabled .cke_button_label {
 	opacity: 0.5;
 }
-
 
 /* Toolbar group separators. */
 /* Separator after last button in the group. */
 .cke_toolgroup a.cke_button:last-child:after,
-.cke_toolgroup a.cke_button.cke_button_disabled:hover:last-child:after
-{
-	content: "";
+.cke_toolgroup a.cke_button.cke_button_disabled:hover:last-child:after {
+	content: '';
 	position: absolute;
 	height: 24px;
 	width: 0;
-	border-right: 1px solid #E7E7ED;	/* $secondary-l3 */
+	border-right: 1px solid #e7e7ed; /* $secondary-l3 */
 	margin-top: 2px;
 	top: 0;
 	right: -7px;
 }
 
 .cke_rtl .cke_toolgroup a.cke_button:last-child:after,
-.cke_rtl .cke_toolgroup a.cke_button.cke_button_disabled:hover:last-child:after
-{
+.cke_rtl
+	.cke_toolgroup
+	a.cke_button.cke_button_disabled:hover:last-child:after {
 	border-right: 0;
 	right: auto;
 
@@ -246,17 +220,19 @@ a.cke_button_disabled .cke_button_arrow
 
 .cke_hc .cke_toolgroup a.cke_button:last-child:after,
 .cke_hc .cke_toolgroup a.cke_button.cke_button_disabled:last-child:after,
-.cke_hc .cke_toolgroup a.cke_button.cke_button_disabled:hover:last-child:after
-{
-	border-color:#000;
+.cke_hc .cke_toolgroup a.cke_button.cke_button_disabled:hover:last-child:after {
+	border-color: #000;
 	top: 0;
 	right: -7px;
 }
 
 .cke_hc.cke_rtl .cke_toolgroup a.cke_button:last-child:after,
-.cke_hc.cke_rtl .cke_toolgroup a.cke_button.cke_button_disabled:last-child:after,
-.cke_hc.cke_rtl .cke_toolgroup a.cke_button.cke_button_disabled:hover:last-child:after
-{
+.cke_hc.cke_rtl
+	.cke_toolgroup
+	a.cke_button.cke_button_disabled:last-child:after,
+.cke_hc.cke_rtl
+	.cke_toolgroup
+	a.cke_button.cke_button_disabled:hover:last-child:after {
 	top: 0;
 	right: auto;
 	left: -7px;
@@ -264,42 +240,36 @@ a.cke_button_disabled .cke_button_arrow
 
 .cke_rtl .cke_toolgroup a.cke_button:hover:last-child:after,
 .cke_rtl .cke_toolgroup a.cke_button:focus:last-child:after,
-.cke_rtl .cke_toolgroup a.cke_button.cke_button_on:last-child:after
-{
+.cke_rtl .cke_toolgroup a.cke_button.cke_button_on:last-child:after {
 	top: -1px;
 	right: auto;
 	left: -4px;
 }
 
 .cke_hc .cke_toolgroup a.cke_button:hover:last-child:after,
-.cke_hc .cke_toolgroup a.cke_button.cke_button_on:last-child:after
-{
+.cke_hc .cke_toolgroup a.cke_button.cke_button_on:last-child:after {
 	top: -2px;
 	right: -9px;
 }
 
 .cke_hc.cke_rtl .cke_toolgroup a.cke_button:hover:last-child:after,
-.cke_hc.cke_rtl .cke_toolgroup a.cke_button.cke_button_on:last-child:after
-{
+.cke_hc.cke_rtl .cke_toolgroup a.cke_button.cke_button_on:last-child:after {
 	top: -2px;
 	right: auto;
 	left: -9px;
 }
 
 /* No separator after last button in a group in a row. */
-.cke_toolbar.cke_toolbar_last .cke_toolgroup a.cke_button:last-child:after
-{
+.cke_toolbar.cke_toolbar_last .cke_toolgroup a.cke_button:last-child:after {
 	content: none;
 	border: none;
 	width: 0;
 	height: 0;
 }
 
-
 /* Button inner elements. */
 /* The icon which is a visual representation of the button. */
-.cke_button_icon
-{
+.cke_button_icon {
 	cursor: inherit;
 	background-repeat: no-repeat;
 	width: 16px;
@@ -308,20 +278,17 @@ a.cke_button_disabled .cke_button_arrow
 	display: inline-block;
 }
 
-.cke_rtl .cke_button_icon
-{
+.cke_rtl .cke_button_icon {
 	float: right;
 }
 
-.cke_hc .cke_button_icon
-{
+.cke_hc .cke_button_icon {
 	display: none;
 }
 
 /* The label of the button that stores the name of the feature. By default,
    labels are invisible. They can be revealed on demand though. */
-.cke_button_label
-{
+.cke_button_label {
 	display: none;
 	padding-left: 3px;
 	margin-top: 1px;
@@ -332,15 +299,13 @@ a.cke_button_disabled .cke_button_arrow
 	color: #484848;
 }
 
-.cke_rtl .cke_button_label
-{
+.cke_rtl .cke_button_label {
 	padding-right: 3px;
 	padding-left: 0;
 	float: right;
 }
 
-.cke_hc .cke_button_label
-{
+.cke_hc .cke_button_label {
 	padding: 0;
 	display: inline-block;
 	font-size: 12px;
@@ -348,8 +313,7 @@ a.cke_button_disabled .cke_button_arrow
 
 /* The small arrow available on buttons that can be expanded
    (e.g. the color buttons). */
-.cke_button_arrow
-{
+.cke_button_arrow {
 	/* Arrow in CSS */
 	display: inline-block;
 	margin: 8px 0 0 3px;
@@ -362,14 +326,12 @@ a.cke_button_disabled .cke_button_arrow
 	border-top: 3px solid #484848;
 }
 
-.cke_rtl .cke_button_arrow
-{
+.cke_rtl .cke_button_arrow {
 	margin-right: 5px;
 	margin-left: 0;
 }
 
-.cke_hc .cke_button_arrow
-{
+.cke_hc .cke_button_arrow {
 	font-size: 10px;
 	margin: 3px 0 0 3px;
 	width: auto;
@@ -378,49 +340,42 @@ a.cke_button_disabled .cke_button_arrow
 
 /* The vertical separator which is used within a single toolbar to split
    buttons into sub-groups. */
-.cke_toolbar_separator
-{
+.cke_toolbar_separator {
 	float: left;
-	background-color: #E7E7ED;	/* $secondary-l3 */
+	background-color: #e7e7ed; /* $secondary-l3 */
 	margin: 4px 3px 0 3px;
 	height: 24px;
 	width: 1px;
 }
 
-.cke_rtl .cke_toolbar_separator
-{
+.cke_rtl .cke_toolbar_separator {
 	float: right;
 }
 
-.cke_hc .cke_toolbar_separator
-{
+.cke_hc .cke_toolbar_separator {
 	background-color: #000;
 	margin-left: 2px;
 	margin-right: 5px;
 	margin-bottom: 9px;
 }
-.cke_hc.cke_rtl .cke_toolbar_separator
-{
+.cke_hc.cke_rtl .cke_toolbar_separator {
 	margin-left: 5px;
 	margin-right: 2px;
 }
 
 /* The dummy element that breaks toolbars.
    Once it is placed, the very next toolbar is moved to the new row. */
-.cke_toolbar_break
-{
+.cke_toolbar_break {
 	display: block;
 	clear: left;
 }
 
-.cke_rtl .cke_toolbar_break
-{
+.cke_rtl .cke_toolbar_break {
 	clear: right;
 }
 
 /* The button, which when clicked hides (collapses) all the toolbars. */
-a.cke_toolbox_collapser
-{
+a.cke_toolbox_collapser {
 	width: 12px;
 	height: 11px;
 	float: right;
@@ -432,24 +387,20 @@ a.cke_toolbox_collapser
 	border: 1px solid #bcbcbc;
 }
 
-.cke_rtl .cke_toolbox_collapser
-{
+.cke_rtl .cke_toolbox_collapser {
 	float: left;
 }
 
-.cke_toolbox_collapser:hover
-{
+.cke_toolbox_collapser:hover {
 	background: #e5e5e5;
 }
 
-.cke_toolbox_collapser.cke_toolbox_collapser_min
-{
+.cke_toolbox_collapser.cke_toolbox_collapser_min {
 	margin: 0 2px 4px;
 }
 
 /* The CSS arrow, which belongs to the toolbar collapser. */
-.cke_toolbox_collapser .cke_arrow
-{
+.cke_toolbox_collapser .cke_arrow {
 	display: inline-block;
 
 	/* Pure CSS Arrow */
@@ -461,15 +412,13 @@ a.cke_toolbox_collapser
 	border-bottom-color: #484848;
 }
 
-.cke_toolbox_collapser.cke_toolbox_collapser_min .cke_arrow
-{
+.cke_toolbox_collapser.cke_toolbox_collapser_min .cke_arrow {
 	margin-top: 4px;
 	border-bottom-color: transparent;
 	border-top-color: #484848;
 }
 
-.cke_hc .cke_toolbox_collapser .cke_arrow
-{
+.cke_hc .cke_toolbox_collapser .cke_arrow {
 	font-size: 8px;
 	width: auto;
 	border: 0;


### PR DESCRIPTION
https://issues.liferay.com/browse/IFI-1773

Applying in the moono-lexicon skin the new Lexicon styles already implemented in portal so we can get rid of that styles there.

Once we merge this and release a new liferay-ckeditor version we will need to:
- Remove `_editor_ckeditor.scss`
- Remove `.html-editor.portlet` definition on the `editor_html.scss` theme file.
- Update `BaseCKEditorConfigContributor` to load `moono-lexicon` css instead of `frontend-css-web` one. 

Also I opened [an issue](https://github.com/liferay/liferay-ckeditor/issues/68) to discuss if we should support scss for skins. For this pr I harcoded colors instead using clay variables.

Steps to test this in portal:
- Run `ck.sh build` in `liferay-ckeditor`
- Remove `liferay-ckeditor` folder from `/modules/node_modules` in portal
- Create a symlink to your `liferay-ckeditor` local path in `modules/node_modules` in portal (or just copy the entire project)
- Remove the file `modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_ckeditor.scss` and deploy the module.
- Remove the `.html-editor.portlet` definition from `modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_editor_html.scss` and deploy the module.
- Go to file `modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java` and replace the content with [this one](https://gist.github.com/carloslancha/66774ad1e08605cbe879a956244d7f98)
- Remove `build`, `classes` and `tmp` folders and deploy the module (avoid clean deploy)
- Go to Product Menu / Content & Data / Web Content / New Basic Web Content

Note: I added here styles for the focus state, you need to focus the editor content and then press Alt + F10 (Win) or Option + F10 (Mac) to focus the toolbar in order to test it.

![image](https://user-images.githubusercontent.com/5803434/85066215-cd005b80-b1ae-11ea-9213-5adab374d83f.png)
