### PR TITLE
fix: styles for editable area on source editor mode | #71

### DIFF
--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -185,11 +185,11 @@ Special outer level classes used in this file:
 /* Styles for the editable area */
 .cke_editable {
 	background-color: #f1f2f5; /* $light */
-	height: 100%;
+	height: calc(100% - 12px) !important;
 	margin: 0;
 	padding: 12px 16px 8px 16px;
 	position: absolute;
-	width: 100%;
+	width: calc(100% - 12px) !important;
 }
 
 .cke_editable:after {

--- a/skins/moono-lexicon/presets.css
+++ b/skins/moono-lexicon/presets.css
@@ -18,12 +18,17 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 textarea.cke_source {
 	font-family: 'Courier New', Monospace;
 	font-size: small;
-	background-color: #fff;
+	background-color: #f1f2f5; /* $light */
 	white-space: pre-wrap;
-	border: none;
-	padding: 0;
+	border: 1px solid #e7e7ed; /* $secondary-l3 */
+	padding: 5px;
 	margin: 0;
 	display: block;
+	position: relative;
+}
+
+textarea.cke_source:focus {
+	border: 1px solid #80acff; /* $primary-l1 */
 }
 
 .cke_wysiwyg_frame,


### PR DESCRIPTION
Fixing styles for editable area on source editor mode.

Before:
![image](https://user-images.githubusercontent.com/5803434/85401068-b4e75e00-b559-11ea-9970-5ff8df278e74.png)

After
![image](https://user-images.githubusercontent.com/5803434/85401047-adc05000-b559-11ea-8085-a30e699e44d7.png)
