### PR TITLE
chore: update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@
 /ckeditor-dev
 /ckeditor/samples
 /support
+.github
+.npm


### PR DESCRIPTION
Exclude `.github` and `.npm` directories from package:
fixes #75

Test plan:
run `npm publish --dry-run` to see which files would get published and confirm is doesn't contain a `ckeditor-dev` directory