### PR TITLE
docs: note need to update GitHub releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,49 +130,51 @@ And resetting the changes in the `package.json` and `yarn.lock` files on the `fr
 
 ### Publishing the liferay-ckeditor package to NPM
 
-After successfully building and testing you can publish to NPM.
+1.  After successfully building and testing you can publish to NPM.
 
-```sh
-# Confirm that worktree is clean and up-to-date.
-git checkout master
-git pull upstream master --ff-only
-git status
+    ```sh
+    # Confirm that worktree is clean and up-to-date.
+    git checkout master
+    git pull upstream master --ff-only
+    git status
 
-# See all checks pass locally:
-yarn ci
+    # See all checks pass locally:
+    yarn ci
 
-# See "Choosing a version number" below for guidance about the version number:
-VERSION=4.13.1-liferay.2
+    # See "Choosing a version number" below for guidance about the version number:
+    VERSION=4.13.1-liferay.2
 
-# Update the CHANGELOG:
-npx liferay-changelog-generator --version=$VERSION
+    # Update the CHANGELOG:
+    npx liferay-changelog-generator --version=$VERSION
 
-# Inspect and add changes:
-git add -p CHANGELOG.md
+    # Inspect and add changes:
+    git add -p CHANGELOG.md
 
-yarn version --new-version $VERSION
-```
+    yarn version --new-version $VERSION
+    ```
 
-Running `yarn version` has the following effects:
+    Running `yarn version` has the following effects:
 
--   The "preversion" script will run, which effectively runs `yarn ci` again.
--   The "package.json" gets updated with the new version number.
--   The "version" script will run, which checks that the proposed version number matches the expected format and corresponds to the version in the CKEditor submodule and build artifacts.
--   A tagged commit is created, including the changes to the CHANGELOG that you staged in a prior step.
--   The "postversion" script will run, which automatically does `git push` and performs a `yarn publish`, prompting for confirmation along the way.
+    -   The "preversion" script will run, which effectively runs `yarn ci` again.
+    -   The "package.json" gets updated with the new version number.
+    -   The "version" script will run, which checks that the proposed version number matches the expected format and corresponds to the version in the CKEditor submodule and build artifacts.
+    -   A tagged commit is created, including the changes to the CHANGELOG that you staged in a prior step.
+    -   The "postversion" script will run, which automatically does `git push` and performs a `yarn publish`, prompting for confirmation along the way.
 
-After the release, you can confirm that the packages are correctly listed in the NPM registry:
+2.  Paste the relevant section from the CHANGELOG.md to [the corresponding release page](https://github.com/liferay/liferay-ckeditor/releases).
 
--   https://www.npmjs.com/package/liferay-ckeditor
+3.  **NOTE:** One effect of using version numbers that include a `-liferay` suffix is that `liferay-js-publish` will interpret them as prerelease versions, in compliance with [how NPM defines prerelease ranges](https://docs.npmjs.com/misc/semver#prerelease-tags) (in agreement with [the SemVer spec](https://semver.org/#spec-item-9)). This means that they will get a `prelease` tag in the NPM registry instead of the default `latest` tag. If you wish to, you can remove this unwanted `prelease` tag and point the `latest` tag at the version you just released with:
 
-**NOTE:** One effect of using version numbers that include a `-liferay` suffix is that `liferay-js-publish` will interpret them as prerelease versions, in compliance with [how NPM defines prerelease ranges](https://docs.npmjs.com/misc/semver#prerelease-tags) (in agreement with [the SemVer spec](https://semver.org/#spec-item-9)). This means that they will get a `prelease` tag in the NPM registry instead of the default `latest` tag. If you wish to, you can remove this unwanted `prelease` tag and point the `latest` tag at the version you just released with:
+    ```sh
+    npm dist-tag rm liferay-ckeditor prerelease
+    npm dist-tag add liferay-ckeditor@$VERSION latest
+    ```
 
-```sh
-npm dist-tag rm liferay-ckeditor prerelease
-npm dist-tag add liferay-ckeditor@$VERSION latest
-```
+    But in practice, this is optional because we always use an exact version specifier when referencing liferay-ckeditor from [liferay-portal](https://github.com/liferay/liferay-portal) ([example](https://github.com/brianchandotcom/liferay-portal/pull/87677/files)).
 
-But in practice, this is optional because we always use an exact version specifier when referencing liferay-ckeditor from [liferay-portal](https://github.com/liferay/liferay-portal) ([example](https://github.com/brianchandotcom/liferay-portal/pull/87677/files)).
+4.  After the release, you can confirm that the packages are correctly listed in the NPM registry:
+
+    -   https://www.npmjs.com/package/liferay-ckeditor
 
 #### Choosing a version number
 


### PR DESCRIPTION
ie. https://github.com/liferay/liferay-ckeditor/releases

We didn't do it for the https://github.com/liferay/liferay-ckeditor/releases/tag/v4.13.1-liferay.6 and https://github.com/liferay/liferay-ckeditor/releases/tag/v4.13.1-liferay.7 because it is not explicitly noted in the README, but it should be.