### PR TITLE
fix: move dev deps out of "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
 	"license": "(GPL-2.0-or-later OR LGPL-2.1 OR MPL-1.1)",
 	"private": false,
 	"devDependencies": {
-		"prettier": "2.0.4"
+		"@clayui/css": "^3.13.0",
+		"prettier": "2.0.4",
+		"sharp": "^0.25.4"
 	},
 	"scripts": {
 		"check:submodule": "node support/checkSubmodule.js",
@@ -20,9 +22,5 @@
 		"postversion": "npx liferay-js-publish",
 		"format": "prettier --write \"skins/**/*.css\" \"support/*.js\" \"*.json\" \"*.md\"",
 		"format:check": "prettier --list-different \"support/*.js\" \"*.json\" \"*.md\""
-	},
-	"dependencies": {
-		"@clayui/css": "^3.13.0",
-		"sharp": "^0.25.4"
 	}
 }


### PR DESCRIPTION
These are build-time only deps and do not belong in "devDependencies", and will drag a lot of garbage into liferay-portal.

Compare the size of a release prepared with these deps (eg. v4.13.1-liferay.7) with an earlier release (eg. v4.13.1-liferay.5):

    # v4.13.1-liferay.7
    mkdir current
    cd !$
    yarn init -y
    yarn add liferay-ckeditor
    du -sh
     58M    .
    find . -type f | wc -l
        4376
    yarn list | wc -l
        200 # 1 of these is package itself, 2 are metadata

    # v4.13.1-liferay.5
    mkdir ../previous
    cd !$
    yarn init -y
    yarn add liferay-ckeditor@v4.13.1-liferay.5
    du -sh
     11M    .
    find . -type f | wc -l
        1567
    yarn list | wc -l
        3 # 1 of these is package itself, 2 are metadata

ie. package grew from 11 MB (1,567 files, 0 dependencies) to 58M (4,376 files, 197 dependencies).