### PR TITLE
docs: update stale reference to non-existent "buildskin" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,5 +201,5 @@ An example of this can be seen in [this PR](https://github.com/brianchandotcom/l
 
 1. Create a new skin running `sh ck.sh createskin`.
 2. Edit the skin at `/skins/yourskin` folder.
-3. Build the skin running `sh ck.sh buildskin`.
+3. Build the skin running `sh ck.sh build`.
 4. Commit the result.


### PR DESCRIPTION
There is no "buildskin" subcommand any more, because we folded that into the "build" subcommand.