### PR TITLE
feat: bundle the a11ychecker plugin

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -77,6 +77,10 @@ case "$COMMAND" in
 				# Replace with new build files.
 				cp -r dev/builder/release/ckeditor/* ../ckeditor/
 
+				# Concatenate jQuery with the a11ychecker plugin
+				(cat ../node_modules/jquery/dist/jquery.min.js ../ckeditor/plugins/a11ychecker/plugin.js) > ../ckeditor/plugins/a11ychecker/plugin.jquery.js
+				mv ../ckeditor/plugins/a11ychecker/plugin.jquery.js ../ckeditor/plugins/a11ychecker/plugin.js
+
 				cd ..
 				if [ -n "$DEBUG" ]; then
 					echo

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"private": false,
 	"devDependencies": {
 		"@clayui/css": "^3.13.0",
+		"jquery": "^3.5.1",
 		"prettier": "2.0.4",
 		"sharp": "^0.25.4"
 	},
@@ -22,5 +23,6 @@
 		"postversion": "npx liferay-js-publish",
 		"format": "prettier --write \"skins/**/*.css\" \"support/*.js\" \"*.json\" \"*.md\"",
 		"format:check": "prettier --list-different \"support/*.js\" \"*.json\" \"*.md\""
-	}
+	},
+	"dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,6 +224,11 @@ isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 mimic-response@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"


### PR DESCRIPTION
Test plan:

- Run `./ck.sh build`
- Use the custom build in `liferay-portal`
- Enable the `a11ychecker` plugin
- See it working

Notes: 

- Until [#85](https://github.com/liferay/liferay-ckeditor/pull/85) is merged you will get an error about missing CSS files from the
`balloonpanel` plugin but it won't prevent the `a11ychecker` plugin to
work - the styles will just be a bit broken)
- This will create a global `jQuery` object: `a11ychecker` (and also 
  [`./ckeditor/adapters/jquery.js`](https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/adapters/jquery.js)) expect `window.jQuery` to be defined 
   but we can improve that later on if everyone agrees
