### PR TITLE
docs: remove instruction to "git commit" after building

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ And resetting the changes in the `package.json` and `yarn.lock` files on the `fr
 
     # Build and commit.
     sh ck.sh build
-    git commit -m "chore: build CKEditor"
     ```
 
     **NOTE:** Check that only files in `ckeditor` folder are being committed.


### PR DESCRIPTION
Seeing as it happens automatically since 43074c10c7.

I previously tried to update the docs to describe the new behavior in 415322d2ea, but I missed this reference.