### PR TITLE
feat: hide button labels when editor size is small

### DIFF
--- a/skins/moono-lexicon/presets.css
+++ b/skins/moono-lexicon/presets.css
@@ -9,6 +9,15 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	display: inline;
 }
 
+/* Hide button labels on 768px breakpoint */
+@media (max-width: 768px) {
+	.cke_button__label,
+	.cke_button__source_label,
+	.cke_button__sourcedialog_label {
+		display: none;
+	}
+}
+
 /* "Font Size" panel size */
 .cke_combopanel__fontsize {
 	width: 135px;


### PR DESCRIPTION
The goal of this task is to hide button labels when editor size is small.
I made the changes by modifying `preset.css` files in all skins of `liferay-ckeditor`. 
This sheet contains custom styles specifically for these buttons
- https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/skins/kama/presets.css
- https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/skins/moono-lisa/presets.css
- https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/skins/moono/presets.css
- https://github.com/liferay/liferay-ckeditor/blob/master/skins/moono-lexicon/presets.css

As it is visible ine the linked files above, all these files contain duplicated styles, so I added styles following the same pattern.
Adding `768px` media query breakpoint with adding `display:none` on `cke_button_label`, `cke_button__source_label` and `cke_button__sourcedialog_label` classes does the trick.