### PR TITLE
fix: remove positioning and size definition of the editable area as is notlonger needed and was interfering with alloy editor styling

### DIFF
--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -185,11 +185,8 @@ Special outer level classes used in this file:
 /* Styles for the editable area */
 .cke_editable {
 	background-color: #f1f2f5; /* $light */
-	height: calc(100% - 12px) !important;
 	margin: 0;
 	padding: 12px 16px 8px 16px;
-	position: absolute;
-	width: calc(100% - 12px) !important;
 }
 
 .cke_editable:after {


### PR DESCRIPTION
We changed the skin Alloy Editor is using for CKEditor in portal to `moono-lisa` since its styling was made based on that one, but we're still having problems when both Alloy Editor and CKEditor are in the page 'cause they share classnames such as `ckeditor_editable`:

![image](https://user-images.githubusercontent.com/5803434/87167674-a032f600-c2cd-11ea-86ec-f874f2399112.png)

Removing this css properties, that are not longer needed, fixes this particular problem.