### PR TITLE
fix: add border property to outer class required for resizing

### DIFF
--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -48,6 +48,7 @@ Special outer level classes used in this file:
 /* The outer boundary of the interface. */
 .cke_chrome {
 	/* This is <span>, so transform it into a block.*/
+	border: 1px solid transparent;
 	display: block;
 	padding: 0;
 }


### PR DESCRIPTION
This PR is the fix of the https://issues.liferay.com/browse/LPS-117074 bug when CKEditor breaks on resize. 
This bug occured because `moono-lexicon` skin’s `cke_chrome` class is missing border.
It is required because `resize` takes outer element’s border property to calculate width and height when resizing. 