### PR TITLE
fix: remove padding and background-color in page editor .cke_editable

### DIFF
--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -207,3 +207,10 @@ Special outer level classes used in this file:
 .cke_editable:focus:after {
 	border-color: #80acff; /* $primary-l1 */
 }
+
+/* Page editor inline editor specific style for reseting backgorund color and padding
+*/
+.page-editor__fragment-content .cke_editable {
+	background-color: unset;
+	padding: 0;
+}


### PR DESCRIPTION
This is a bug fix for https://issues.liferay.com/browse/LPS-117468
Reseting border and background styles for cke_editable css class in page editor.

The issue with overlay that is preventing unrelated UI interactions on the page should be fixed in https://github.com/liferay/liferay-ckeditor/pull/98

Steps to reproduce

1. Edit Hello World page (or create a content page with a heading fragment)
2. Double click on a text editable to start editing.

Also, see below a video