### PR TITLE
fix: remove comments from svg icons

### DIFF
--- a/support/iconsClassesGenerator.js
+++ b/support/iconsClassesGenerator.js
@@ -24,6 +24,7 @@ const encodeSvgData = (svgData, color) => {
 	const symbols = /[\r\n%#()<>?\[\\\]^`{|}]/g;
 
 	return svgData
+		.replace(/<!--.*?-->/gs, '')
 		.replace(/(<svg[^>]*)( fill="[^"]+")/, '\1')
 		.replace(/<svg/, `<svg fill="${color}"`)
 		.replace(/"/g, "'") // Use single quotes instead of double to avoid encoding.


### PR DESCRIPTION
Solving https://issues.liferay.com/browse/LPS-118249

Remove comments from svg icons on css classes generation.

Copyright comments were introduced to Clay svg on https://github.com/liferay/clay/commit/13ae645d0fd90da6be1100f11430af259ff2f2c7#diff-214a1e2a1d78797d9528f65bfa7504ee