### PR TITLE
fix: Don't pass languageId to css files requests

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,7 +1,7 @@
-From 8bb123947bf25d742f076fcd9facb94daa03fb27 Mon Sep 17 00:00:00 2001
+From bb8157502a44ede7c8b1806ef63fcdf3554e8089 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
-Subject: [PATCH 1/5] LPS-89596 Cannot Drag Image from top content line in IE11
+Subject: [PATCH 1/6] LPS-89596 Cannot Drag Image from top content line in IE11
  using Alloy Editor
 
 Changed position of drag icon for IE.
@@ -25,5 +25,5 @@ index 1d4e036fc..a53a4c809 100644
  				return;
  
 -- 
-2.27.0
+2.23.0
 

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,7 +1,7 @@
-From 7f7f913b44304631f18fa2e9ecac7784adf77452 Mon Sep 17 00:00:00 2001
+From 30fce10a6a6b640ab317ad7cb96a540940afdcd2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
-Subject: [PATCH 2/5] LPS-95472 Tabs in popups not appears correctly in
+Subject: [PATCH 2/6] LPS-95472 Tabs in popups not appears correctly in
  maximized CKEditor
 
 Use `width: inherit` instead of `width: 100%` to work with the maximize
@@ -24,5 +24,5 @@ index 022d7b473..5537eef39 100644
  				contentMap = this._.contents[ contents.id ] = {},
  				cursor,
 -- 
-2.27.0
+2.23.0
 

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,7 +1,7 @@
-From 73347eea4d99e153bec3d26eb1f980011d90afbb Mon Sep 17 00:00:00 2001
+From f22231335a80630b23d7af98508585cd2650d2c3 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
-Subject: [PATCH 3/5] LPS-85326 Remove check for Webkit browsers
+Subject: [PATCH 3/6] LPS-85326 Remove check for Webkit browsers
 
 As described in this issue:
 
@@ -31,5 +31,5 @@ index 0c0cb261c..dd7f4701e 100644
  						// move the selection by itself (https://dev.ckeditor.com/ticket/1272).
  						var fillingChar = createFillingCharSequenceNode( this.root );
 -- 
-2.27.0
+2.23.0
 

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,7 +1,7 @@
-From fc757da8aa55d2eef4bc391c9d77fd696bc8bb5f Mon Sep 17 00:00:00 2001
+From a966d5de4173b0b480c988a9c578577bd7170526 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
-Subject: [PATCH 4/5] LPP-36989 Remove obsolete summary field from table
+Subject: [PATCH 4/6] LPP-36989 Remove obsolete summary field from table
  elements
 
 ---
@@ -406,5 +406,5 @@ index 15d0ef124..42ef17a6e 100644
  	<tr>
  		<td>cell1</td>
 -- 
-2.27.0
+2.23.0
 

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,7 +1,7 @@
-From 498269a5dd72249555f905022e5a5953410e04a3 Mon Sep 17 00:00:00 2001
+From 11801b3f4995cd1799ec00ecef35252898c54757 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
-Subject: [PATCH 5/5] LPS-112982 Add additional resource URL parameters
+Subject: [PATCH 5/6] LPS-112982 Add additional resource URL parameters
 
 ---
  core/ckeditor_base.js | 25 ++++++++++++++++++-------
@@ -67,5 +67,5 @@ index 8a1ddb6e4..966d798d3 100644
   * Used in conjunction with the {@link CKEDITOR.config#enterMode}
   * and {@link CKEDITOR.config#shiftEnterMode} configuration
 -- 
-2.27.0
+2.23.0
 

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,0 +1,25 @@
+From a62acb27ffd532f3c3bb00e9ad727b62a95e9af6 Mon Sep 17 00:00:00 2001
+From: Carlos Lancha <carlos.lancha@liferay.com>
+Date: Thu, 6 Aug 2020 14:42:21 +0200
+Subject: [PATCH 6/6] LPS-118624 Don't pass languageId to css files requests
+
+---
+ core/ckeditor_base.js | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
+index a6ce37594..6d9fcbc03 100644
+--- a/core/ckeditor_base.js
++++ b/core/ckeditor_base.js
+@@ -184,7 +184,7 @@ if ( !window.CKEDITOR ) {
+ 						var key = entries[0];
+ 						var value = entries[1];
+ 
+-						if (!resourceUrl.searchParams.has(key)) {
++						if (!resourceUrl.searchParams.has(key) && !(resourceUrl.toString().includes('.css') && key === 'languageId')) {
+ 							resourceUrl.searchParams.set(key, value);
+ 						}
+ 					});
+-- 
+2.23.0
+


### PR DESCRIPTION
Fixing https://issues.liferay.com/browse/LPS-118624

Patching ckeditor so `languageId` is not passed to `css` requests