### PR TITLE
feat: reduce noise created by patch updates

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -207,7 +207,7 @@ case "$COMMAND" in
 		echo "Generating patches."
 		echo
 
-		git format-patch "$sha1" -o ../patches
+		git format-patch --no-numbered --no-signature "$sha1" -o ../patches
 
 		echo
 		echo "✅ DONE"

--- a/ck.sh
+++ b/ck.sh
@@ -207,7 +207,7 @@ case "$COMMAND" in
 		echo "Generating patches."
 		echo
 
-		git format-patch --no-numbered --no-signature "$sha1" -o ../patches
+		git format-patch --diff-algorithm=histogram --no-numbered --no-signature "$sha1" -o ../patches
 
 		echo
 		echo "✅ DONE"


### PR DESCRIPTION
As described here:

https://github.com/liferay/liferay-ckeditor/pull/108#issuecomment-669938087

Some of the noise is due to the user doing the update using a different version of Git, so the version number changes.

Some of it is due to the total number of patches changes, so each subject must change too.

We can avoid both of these by adding the `--no-signature` and `--no-numbered` switches to our `git format-patch` call.

Note though that we can't really stop the SHA-1's from changing if a rebase or other mutation is involved, but they will probable stay stable otherwise.

Test plan:

1. Recreate patches and get [this cleaner output](https://github.com/liferay/liferay-ckeditor/commit/0b67c64af91dd710177fcf8372e02a62f9d9f7d5).
2. Recreate patches _again_ and see no changes.

cc @jbalsas @carloslancha