### PR TITLE
feat: add toolbarwatcher plugin

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -56,6 +56,8 @@ case "$COMMAND" in
 				# Copy custom skin to ckeditor-dev
 				cp -r skins/moono-lexicon ckeditor-dev/skins/moono-lexicon
 
+				cp -r plugins ckeditor-dev
+
 				# Copy skin files for plugins
 				pluginsWithSkins=$(find ckeditor-dev/plugins -maxdepth 2 -mindepth 2 -type d -name skins)
 				for plugin in $pluginsWithSkins; do

--- a/plugins/toolbarwatcher/plugin.js
+++ b/plugins/toolbarwatcher/plugin.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+(function () {
+	'use strict';
+
+	var PLUGIN_NAME = 'toolbarwatcher';
+
+	if (!CKEDITOR.plugins.get(PLUGIN_NAME)) {
+		var TOOLBAR_HIDDEN_LABELS_CLASS = 'cke_hide_toolbar_labels';
+
+		function debounce(fn, delay) {
+			return function debounced() {
+				var args = Array.prototype.slice.call(arguments);
+				clearTimeout(debounced.id);
+				debounced.id = setTimeout(function () {
+					fn.apply(null, args);
+				}, delay);
+			};
+		}
+
+		CKEDITOR.plugins.add(PLUGIN_NAME, {
+			afterInit: function (editor) {
+				this.editor = editor;
+				this.editor.on(
+					'instanceReady',
+					this.onInstanceReady.bind(this)
+				);
+			},
+
+			editor: null,
+
+			getToolbarsWidth: function () {
+				var containerElement = this.editor.container.$;
+
+				var width = 0;
+
+				containerElement
+					.querySelectorAll('.cke_toolbar')
+					.forEach(function (element) {
+						width += element.offsetWidth;
+					});
+
+				return width;
+			},
+
+			isToolbarOverflowing: function () {
+				var toolbarsContainer = this.editor.container.$.querySelector(
+					'.cke_top'
+				);
+
+				if (toolbarsContainer) {
+					var toolbarsContainerWidth =
+						parseInt(
+							getComputedStyle(toolbarsContainer).width,
+							10
+						) || 0;
+
+					return this.labeledToolbarsWidth >= toolbarsContainerWidth;
+				}
+
+				return false;
+			},
+
+			labeledToolbarsWidth: 0,
+
+			onInstanceReady: function (event) {
+				var instance = this;
+
+				this.labeledToolbarsWidth = this.getToolbarsWidth();
+
+				event.editor.window.on(
+					'resize',
+					debounce(function () {
+						var containerElement = instance.editor.container.$;
+						var isToolbarOverflowing = instance.isToolbarOverflowing();
+
+						if (isToolbarOverflowing) {
+							if (
+								!containerElement.classList.contains(
+									TOOLBAR_HIDDEN_LABELS_CLASS
+								)
+							) {
+								containerElement.classList.add(
+									TOOLBAR_HIDDEN_LABELS_CLASS
+								);
+							}
+						} else {
+							if (
+								containerElement.classList.contains(
+									TOOLBAR_HIDDEN_LABELS_CLASS
+								)
+							) {
+								containerElement.classList.remove(
+									TOOLBAR_HIDDEN_LABELS_CLASS
+								);
+							}
+						}
+					}, 100)
+				);
+			},
+
+			onLoad: function () {
+				CKEDITOR.addCss(
+					'.cke_hide_toolbar_labels .cke_button__label,' +
+						'.cke_hide_toolbar_labels .cke_button__source_label,' +
+						'.cke_hide_toolbar_labels .cke_button__sourcedialog_label {' +
+						'display: none; }'
+				);
+			}
+		});
+	}
+})();

--- a/plugins/toolbarwatcher/plugin.js
+++ b/plugins/toolbarwatcher/plugin.js
@@ -17,6 +17,8 @@
 
 	var PLUGIN_NAME = 'toolbarwatcher';
 
+	var stylesLoaded = false;
+
 	if (!CKEDITOR.plugins.get(PLUGIN_NAME)) {
 		var TOOLBAR_HIDDEN_LABELS_CLASS = 'cke_hide_toolbar_labels';
 
@@ -55,6 +57,15 @@
 				return width;
 			},
 
+			init: function(editor) {
+				if (!stylesLoaded) {
+					CKEDITOR.document.appendStyleSheet(
+						this.path + 'skins/default.css'
+					);
+					stylesLoaded = true;
+				}
+			},
+
 			isToolbarOverflowing: function () {
 				var toolbarsContainer = this.editor.container.$.querySelector(
 					'.cke_top'
@@ -83,6 +94,8 @@
 				event.editor.window.on(
 					'resize',
 					debounce(function () {
+						instance.labeledToolbarsWidth = instance.getToolbarsWidth();
+
 						var containerElement = instance.editor.container.$;
 						var isToolbarOverflowing = instance.isToolbarOverflowing();
 
@@ -107,18 +120,10 @@
 								);
 							}
 						}
-					}, 100)
-				);
-			},
-
-			onLoad: function () {
-				CKEDITOR.addCss(
-					'.cke_hide_toolbar_labels .cke_button__label,' +
-						'.cke_hide_toolbar_labels .cke_button__source_label,' +
-						'.cke_hide_toolbar_labels .cke_button__sourcedialog_label {' +
-						'display: none; }'
+					}, 50)
 				);
 			}
+
 		});
 	}
 })();

--- a/plugins/toolbarwatcher/skins/default.css
+++ b/plugins/toolbarwatcher/skins/default.css
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+.cke_hide_toolbar_labels .cke_button__label,
+.cke_hide_toolbar_labels .cke_button__source_label,
+.cke_hide_toolbar_labels .cke_button__sourcedialog_label {
+	display: none;
+}

--- a/support/build-config.js
+++ b/support/build-config.js
@@ -62,6 +62,7 @@ var CKBUILDER_CONFIG = {
 		table: 1,
 		tabletools: 1,
 		toolbar: 1,
+		toolbarwatcher: 1,
 		undo: 1,
 		wysiwygarea: 1,
 	},


### PR DESCRIPTION
In order to solve https://issues.liferay.com/browse/LPS-116683,
and based on liferay-frontend/liferay-portal#182,
add a new plugin to control the visibility of toolbar labels in CKEditor

**Screenshot**

![toolbarwatcher](https://user-images.githubusercontent.com/5572/89621530-c8445380-d891-11ea-81f0-79e2db279411.gif)
