### PR TITLE
fix: add the ability to center images

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From bb8157502a44ede7c8b1806ef63fcdf3554e8089 Mon Sep 17 00:00:00 2001
+From cf6e3c184a4e75fc37f958246509d748141e7905 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 30fce10a6a6b640ab317ad7cb96a540940afdcd2 Mon Sep 17 00:00:00 2001
+From 2d6ec908dc0fdabbccad7d252b0ebe1d21a059dc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From f22231335a80630b23d7af98508585cd2650d2c3 Mon Sep 17 00:00:00 2001
+From 2ad16b2b2f20d10c479b56e952a5ae1d49892b8a Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From a966d5de4173b0b480c988a9c578577bd7170526 Mon Sep 17 00:00:00 2001
+From c625ef71414f30ea41d387812464d824773d64d5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 11801b3f4995cd1799ec00ecef35252898c54757 Mon Sep 17 00:00:00 2001
+From cc357f218ef661778d70131e3997f88223e8b115 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From a62acb27ffd532f3c3bb00e9ad727b62a95e9af6 Mon Sep 17 00:00:00 2001
+From 0657b1fe2991a97aa94e56ccfba25833f59baf8d Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-115747-Add-the-ability-to-center-images.patch
+++ b/patches/0007-LPS-115747-Add-the-ability-to-center-images.patch
@@ -1,0 +1,88 @@
+From 8e342f43622a2519a89304f19a44f2a399c8a8d5 Mon Sep 17 00:00:00 2001
+From: Julien Castelain <julien.castelain@liferay.com>
+Date: Thu, 13 Aug 2020 12:34:29 +0200
+Subject: [PATCH] LPS-115747 Add the ability to center images
+
+---
+ plugins/image/dialogs/image.js | 35 +++++++++++++++++++++++++++-------
+ 1 file changed, 28 insertions(+), 7 deletions(-)
+
+diff --git a/plugins/image/dialogs/image.js b/plugins/image/dialogs/image.js
+index acd7b66db..a9447b90e 100644
+--- a/plugins/image/dialogs/image.js
++++ b/plugins/image/dialogs/image.js
+@@ -911,7 +911,7 @@
+ 								},
+ 								{
+ 									id: 'cmbAlign',
+-									requiredContent: 'img{float}',
++									requiredContent: 'img{display,float,margin}',
+ 									type: 'select',
+ 									widths: [ '35%', '65%' ],
+ 									style: 'width:90px',
+@@ -920,6 +920,7 @@
+ 									items: [
+ 										[ editor.lang.common.notSet, '' ],
+ 										[ editor.lang.common.left, 'left' ],
++										[ editor.lang.common.center, 'center' ],
+ 										[ editor.lang.common.right, 'right' ]
+ 										// Backward compatible with v2 on setup when specified as attribute value,
+ 										// while these values are no more available as select options.
+@@ -937,12 +938,21 @@
+ 									},
+ 									setup: function( type, element ) {
+ 										if ( type == IMAGE ) {
+-											var value = element.getStyle( 'float' );
+-											switch ( value ) {
++											var displayValue = element.getStyle( 'display' );
++											var floatValue = element.getStyle( 'float' );
++											var marginValue = element.getStyle( 'margin' );
++
++											switch ( floatValue ) {
+ 												// Ignore those unrelated values.
+ 												case 'inherit':
+ 												case 'none':
+-													value = '';
++													floatValue = '';
++											}
++
++											var value = floatValue;
++
++											if (displayValue === 'block' && marginValue === '0px auto') {
++												value = 'center';
+ 											}
+ 
+ 											!value && ( value = ( element.getAttribute( 'align' ) || '' ).toLowerCase() );
+@@ -952,10 +962,19 @@
+ 									commit: function( type, element ) {
+ 										var value = this.getValue();
+ 										if ( type == IMAGE || type == PREVIEW ) {
+-											if ( value )
+-												element.setStyle( 'float', value );
+-											else
++											if ( value ) {
++												if ( value === 'left' || value === 'right' ) {
++													element.setStyle( 'float', value );
++												}
++												else if (value === 'center') {
++													element.setStyle('display', 'block');
++													element.setStyle('margin', '0px auto');
++												}
++											} else {
+ 												element.removeStyle( 'float' );
++												element.removeStyle( 'margin' );
++												element.removeStyle( 'display' );
++											}
+ 
+ 											if ( type == IMAGE ) {
+ 												value = ( element.getAttribute( 'align' ) || '' ).toLowerCase();
+@@ -968,7 +987,9 @@
+ 												}
+ 											}
+ 										} else if ( type == CLEANUP ) {
++											element.removeStyle( 'display' );
+ 											element.removeStyle( 'float' );
++											element.removeStyle( 'margin' );
+ 										}
+ 									}
+ 								} ]


### PR DESCRIPTION
This fixes [https://issues.liferay.com/browse/LPS-115747](https://issues.liferay.com/browse/LPS-115747).

The `image` plugin's dialog has been patched and now shows an option to "center" images

**Before**

![before](https://user-images.githubusercontent.com/5572/90126962-bcaace00-dd64-11ea-977d-f9b7ec8b066b.gif)

**After**

![centered-image](https://user-images.githubusercontent.com/5572/90126980-c2a0af00-dd64-11ea-965e-a9d0d5930d9a.gif)

Note: you'll have to trust me that the `console.log` message that appear in the second .gif have been removed (although that's visible in the patch)
