### PR TITLE
refactor: enable the `image2` plugin

### DIFF
--- a/support/build-config.js
+++ b/support/build-config.js
@@ -43,7 +43,7 @@ var CKBUILDER_CONFIG = {
 		font: 1,
 		format: 1,
 		horizontalrule: 1,
-		image: 1,
+		image2: 1,
 		indentlist: 1,
 		indentblock: 1,
 		justify: 1,


### PR DESCRIPTION
in order to complete [https://issues.liferay.com/browse/LPS-115747](https://issues.liferay.com/browse/LPS-115747),
enable the `image2` plugin which allows center align images as well as
resizing them