### PR TITLE
feat: add codemirror dialog

### DIFF
--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -1,0 +1,108 @@
+CKEDITOR.dialog.add('codemirrordialog', function(editor) {
+	var editorWindow = CKEDITOR.document.getWindow();
+	var size = editorWindow.getViewPaneSize();
+	var scalex = 0.9;
+	var scaley = 0.7;
+	var height = size.height * scaley;
+	var width = size.width * scalex;
+
+	if (!editor.window) {
+		editor.window = editorWindow;
+	}
+
+	return {
+		_createCodeMirrorEditor: function() {
+			var dialog = this.dialog;
+
+			var size = dialog.getSize();
+
+			var textarea = dialog.getContentElement('main', 'data')
+				.getInputElement().$;
+
+			var codeMirrorEditor = this.codeMirrorEditor =
+				CodeMirror.fromTextArea(
+					textarea,
+					{
+						lineNumbers: true,
+						lineWrapping: true,
+						mode: 'text/html'
+					}
+				);
+
+			var defaultWidth = (size.width * 0.5) - 10;
+
+			codeMirrorEditor.setSize(defaultWidth, null);
+
+			var editor = dialog.getParentEditor();
+
+			codeMirrorEditor.setValue(
+				html_beautify(editor.getData(true))
+			);
+
+			var preview = dialog.getContentElement('main', 'preview').getElement();
+			preview.setHtml(codeMirrorEditor.getValue());
+			preview.setSize('width', defaultWidth);
+
+			codeMirrorEditor.on(
+				'change',
+				this._handleCodeMirrorChange.bind(this)
+			);
+		},
+
+		_handleCodeMirrorChange: function() {
+			var newData = this.codeMirrorEditor.getValue();
+			var preview = this.dialog.getContentElement('main', 'preview').getElement();
+
+			preview.setHtml(newData);
+		},
+
+		contents: [{
+			id: 'main',
+			elements: [{
+				align: 'top',
+				children: [
+					{
+						id: 'data',
+						type: 'textarea'
+					},
+					{
+						html: '<div class="code_preview">&nbsp;</div>',
+						id: 'preview',
+						type: 'html'
+					}
+				],
+				type: 'hbox'
+			}]
+		}],
+
+		height: height,
+		title: editor.lang.codemirror.source,
+		width: width,
+
+		onLoad: function() {
+			this.definition._createCodeMirrorEditor();
+		},
+
+		onOk: function() {
+			var definition = this.definition;
+			var editor = this.getParentEditor();
+			var newData = definition.codeMirrorEditor.getValue();
+			var oldData = editor.getData();
+
+			if (newData !== oldData) {
+				editor.setData(newData);
+				editor.setMode('wysiwyg');
+			}
+		},
+
+		onShow: function() {
+			var codeMirrorEditor = this.definition.codeMirrorEditor;
+			var editor = this.getParentEditor();
+			var data = editor.getData();
+
+			if (codeMirrorEditor && codeMirrorEditor.getValue() !== data) {
+				codeMirrorEditor.setValue(html_beautify(data));
+			}
+		}
+	};
+});

--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -3,12 +3,9 @@
 
 	var stylesLoaded = false;
 
-
 	CKEDITOR.plugins.add('codemirror', {
 		_createCodeMirrorEditor: function(editor) {
 			var instance = this;
-
-			var codemirror = CKEDITOR.plugins.codemirror;
 
 			editor.addMode('source', function(callback) {
 				var contentsSpace = editor.ui.space('contents');
@@ -36,8 +33,6 @@
 
 				callback();
 			});
-
-			editor.addCommand('codemirror', codemirror.commands.source);
 		},
 
 		_handleCodeMirrorChange: function(editor, oldData) {
@@ -69,6 +64,10 @@
 
 			if (!stylesLoaded) {
 				CKEDITOR.document.appendStyleSheet(
+					this.path + 'skins/default.css'
+				);
+
+				CKEDITOR.document.appendStyleSheet(
 					this.path + 'vendors/vendors.css'
 				);
 				stylesLoaded = true;
@@ -80,11 +79,38 @@
 				}
 			);
 
+			editor.addCommand('codemirror', CKEDITOR.plugins.codemirror.commands.source);
+
+			editor.addCommand(
+				'codemirrordialog',
+				CKEDITOR.tools.extend(
+					new CKEDITOR.dialogCommand('codemirrordialog'),
+					{
+						modes: {
+							source: 1,
+							wysiwyg: 0,
+						},
+						state: CKEDITOR.TRISTATE_OFF
+					}
+				)
+			);
+
+			CKEDITOR.dialog.add(
+				'codemirrordialog',
+				this.path + 'dialogs/codemirrordialog.js'
+			);
+
 			if (editor.ui.addButton) {
 				editor.ui.addButton('Source', {
 					label: editor.lang.codemirror.source,
 					command: 'codemirror',
 					toolbar: 'mode,10'
+				});
+
+				editor.ui.addButton('Expand', {
+					label: editor.lang.common.preview,
+					command: 'codemirrordialog',
+					toolbar: 'mode,11'
 				});
 			}
 

--- a/plugins/codemirror/skins/default.css
+++ b/plugins/codemirror/skins/default.css
@@ -17,13 +17,6 @@ a.cke_button__source.cke_button_off + a.cke_button__expand.cke_button_disabled {
 	padding: 0 10px;
 }
 
-.cke_dialog .code_preview hr {
-	border: none;
-	background-color: #ccc;
-	color: #ccc;
-	height: 1px;
-}
-
 .cke_hidpi .cke_button.cke_button_on .cke_button__expand_icon,
 .cke_button.cke_button_on .cke_button__expand_icon {
 background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M64,128v-25.4l88,88c25.5,25.5,64.5-12.8,38.6-38.6l-88-88H128c42.6,0,42.6-64,0-64H32C16.4,0,0,14.4,0,32v96C0,170.7,64,170.6,64,128z%20M448,128v-25.4l-88,88c-25.5,25.5-64.5-12.8-38.6-38.6l88-88H384c-42.6,0-42.6-64,0-64h96c15.6,0,32,14.4,32,32v96C512,170.7,448,170.6,448,128z%20M64,384v25.4l88-88c25.5-25.5,64.5,12.8,38.6,38.6l-88,88H128c42.6,0,42.6,64,0,64H32c-15.6,0-32-14.4-32-32v-96C0,341.3,64,341.4,64,384z%20M448,384v25.4l-88-88c-25.5-25.5-64.5,12.8-38.6,38.6l88,88H384c-42.6,0-42.6,64,0,64h96c15.6,0,32-14.4,32-32v-96C512,341.3,448,341.4,448,384z'/%3E%3C/svg%3E%0A") !important;

--- a/plugins/codemirror/skins/default.css
+++ b/plugins/codemirror/skins/default.css
@@ -1,0 +1,87 @@
+a.cke_button__source.cke_button_off + a.cke_button__expand.cke_button_disabled {
+	display: none;
+}
+
+.cke_dialog .CodeMirror {
+	height: auto;
+}
+
+.cke_dialog .CodeMirror-line * {
+	font-family: monospace;
+	font-size: 13px;
+}
+
+.cke_dialog .code_preview {
+	border-left: 1px solid #bcbcbc;
+	overflow-x: auto;
+	padding: 0 10px;
+}
+
+.cke_dialog .code_preview hr {
+	border: none;
+	background-color: #ccc;
+	color: #ccc;
+	height: 1px;
+}
+
+.cke_hidpi .cke_button.cke_button_on .cke_button__expand_icon,
+.cke_button.cke_button_on .cke_button__expand_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M64,128v-25.4l88,88c25.5,25.5,64.5-12.8,38.6-38.6l-88-88H128c42.6,0,42.6-64,0-64H32C16.4,0,0,14.4,0,32v96C0,170.7,64,170.6,64,128z%20M448,128v-25.4l-88,88c-25.5,25.5-64.5-12.8-38.6-38.6l88-88H384c-42.6,0-42.6-64,0-64h96c15.6,0,32,14.4,32,32v96C512,170.7,448,170.6,448,128z%20M64,384v25.4l88-88c25.5-25.5,64.5,12.8,38.6,38.6l-88,88H128c42.6,0,42.6,64,0,64H32c-15.6,0-32-14.4-32-32v-96C0,341.3,64,341.4,64,384z%20M448,384v25.4l-88-88c-25.5-25.5-64.5,12.8-38.6,38.6l88,88H384c-42.6,0-42.6,64,0,64h96c15.6,0,32-14.4,32-32v-96C512,341.3,448,341.4,448,384z'/%3E%3C/svg%3E%0A") !important;
+}
+.cke_hidpi .cke_button .cke_button__expand_icon,
+.cke_button .cke_button__expand_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%236b6c7e'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M64,128v-25.4l88,88c25.5,25.5,64.5-12.8,38.6-38.6l-88-88H128c42.6,0,42.6-64,0-64H32C16.4,0,0,14.4,0,32v96C0,170.7,64,170.6,64,128z%20M448,128v-25.4l-88,88c-25.5,25.5-64.5-12.8-38.6-38.6l88-88H384c-42.6,0-42.6-64,0-64h96c15.6,0,32,14.4,32,32v96C512,170.7,448,170.6,448,128z%20M64,384v25.4l88-88c25.5-25.5,64.5,12.8,38.6,38.6l-88,88H128c42.6,0,42.6,64,0,64H32c-15.6,0-32-14.4-32-32v-96C0,341.3,64,341.4,64,384z%20M448,384v25.4l-88-88c-25.5-25.5-64.5,12.8-38.6,38.6l88,88H384c-42.6,0-42.6,64,0,64h96c15.6,0,32-14.4,32-32v-96C512,341.3,448,341.4,448,384z'/%3E%3C/svg%3E%0A") !important;
+}
+.cke_hidpi .cke_button.cke_button_disabled .cke_button__expand_icon,
+.cke_button.cke_button_disabled .cke_button__expand_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23a7a9bc'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M64,128v-25.4l88,88c25.5,25.5,64.5-12.8,38.6-38.6l-88-88H128c42.6,0,42.6-64,0-64H32C16.4,0,0,14.4,0,32v96C0,170.7,64,170.6,64,128z%20M448,128v-25.4l-88,88c-25.5,25.5-64.5-12.8-38.6-38.6l88-88H384c-42.6,0-42.6-64,0-64h96c15.6,0,32,14.4,32,32v96C512,170.7,448,170.6,448,128z%20M64,384v25.4l88-88c25.5-25.5,64.5,12.8,38.6,38.6l-88,88H128c42.6,0,42.6,64,0,64H32c-15.6,0-32-14.4-32-32v-96C0,341.3,64,341.4,64,384z%20M448,384v25.4l-88-88c-25.5-25.5-64.5,12.8-38.6,38.6l88,88H384c-42.6,0-42.6,64,0,64h96c15.6,0,32-14.4,32-32v-96C512,341.3,448,341.4,448,384z'/%3E%3C/svg%3E%0A") !important;
+}
+.cke_hidpi .cke_button:not(.cke_button_disabled):hover .cke_button__expand_icon,
+.cke_button:not(.cke_button_disabled):hover .cke_button__expand_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M64,128v-25.4l88,88c25.5,25.5,64.5-12.8,38.6-38.6l-88-88H128c42.6,0,42.6-64,0-64H32C16.4,0,0,14.4,0,32v96C0,170.7,64,170.6,64,128z%20M448,128v-25.4l-88,88c-25.5,25.5-64.5-12.8-38.6-38.6l88-88H384c-42.6,0-42.6-64,0-64h96c15.6,0,32,14.4,32,32v96C512,170.7,448,170.6,448,128z%20M64,384v25.4l88-88c25.5-25.5,64.5,12.8,38.6,38.6l-88,88H128c42.6,0,42.6,64,0,64H32c-15.6,0-32-14.4-32-32v-96C0,341.3,64,341.4,64,384z%20M448,384v25.4l-88-88c-25.5-25.5-64.5,12.8-38.6,38.6l88,88H384c-42.6,0-42.6,64,0,64h96c15.6,0,32-14.4,32-32v-96C512,341.3,448,341.4,448,384z'/%3E%3C/svg%3E%0A") !important;
+}
+.cke_hidpi .cke_button:not(.cke_button_disabled):focus .cke_button__expand_icon,
+.cke_button:not(.cke_button_disabled):focus .cke_button__expand_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M64,128v-25.4l88,88c25.5,25.5,64.5-12.8,38.6-38.6l-88-88H128c42.6,0,42.6-64,0-64H32C16.4,0,0,14.4,0,32v96C0,170.7,64,170.6,64,128z%20M448,128v-25.4l-88,88c-25.5,25.5-64.5-12.8-38.6-38.6l88-88H384c-42.6,0-42.6-64,0-64h96c15.6,0,32,14.4,32,32v96C512,170.7,448,170.6,448,128z%20M64,384v25.4l88-88c25.5-25.5,64.5,12.8,38.6,38.6l-88,88H128c42.6,0,42.6,64,0,64H32c-15.6,0-32-14.4-32-32v-96C0,341.3,64,341.4,64,384z%20M448,384v25.4l-88-88c-25.5-25.5-64.5,12.8-38.6,38.6l88,88H384c-42.6,0-42.6,64,0,64h96c15.6,0,32-14.4,32-32v-96C512,341.3,448,341.4,448,384z'/%3E%3C/svg%3E%0A") !important;
+}
+
+.cke_ltr.cke_hidpi .cke_button.cke_button_on .cke_button__source_icon,
+.cke_ltr .cke_button.cke_button_on .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_ltr.cke_hidpi .cke_button .cke_button__source_icon,
+.cke_ltr .cke_button .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%236b6c7e'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_ltr.cke_hidpi .cke_button.cke_button_disabled .cke_button__source_icon,
+.cke_ltr .cke_button.cke_button_disabled .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23a7a9bc'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_ltr.cke_hidpi .cke_button:not(.cke_button_disabled):hover .cke_button__source_icon,
+.cke_ltr .cke_button:not(.cke_button_disabled):hover .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_ltr.cke_hidpi .cke_button:not(.cke_button_disabled):focus .cke_button__source_icon,
+.cke_ltr .cke_button:not(.cke_button_disabled):focus .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_rtl.cke_hidpi .cke_button.cke_button_on .cke_button__source_icon,
+.cke_rtl .cke_button.cke_button_on .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_rtl.cke_hidpi .cke_button .cke_button__source_icon,
+.cke_rtl .cke_button .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%236b6c7e'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_rtl.cke_hidpi .cke_button.cke_button_disabled .cke_button__source_icon,
+.cke_rtl .cke_button.cke_button_disabled .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23a7a9bc'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_rtl.cke_hidpi .cke_button:not(.cke_button_disabled):hover .cke_button__source_icon,
+.cke_rtl .cke_button:not(.cke_button_disabled):hover .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}
+.cke_rtl.cke_hidpi .cke_button:not(.cke_button_disabled):focus .cke_button__source_icon,
+.cke_rtl .cke_button:not(.cke_button_disabled):focus .cke_button__source_icon {
+background: url("data:image/svg+xml;charset=utf8,%0A%3Csvg%20fill='%23272833'%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3E%3Cpath%20class='lexicon-icon-outline'%20d='M183.23,185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41,94.41c-13.56,13.56-12.04,35.17,0,47.21l94.41,94.41c30.03,30.03,78.71-15.7,47.21-47.21l-70.72-70.58L183.23,185.38z%20M328.77,326.62c-31.09,31.09,16.11,78.3,47.21,47.21l94.41-94.41c13.56-13.56,12.04-35.17,0-47.21l-94.41-94.41c-30.03-30.03-78.71,15.7-47.21,47.21l70.72,70.58L328.77,326.62z'/%3E%3C/svg%3E") !important;
+}


### PR DESCRIPTION
This is the second part of the [LPS-118290](https://issues.liferay.com/browse/LPS-118290) task:
The `codemirror` plugin has been updated and now includes a dialog that
can be used to edit and preview the code, when the editor is in `source`
mode

Here's a screenshot of the dialog in action:

![codemirrordialog](https://user-images.githubusercontent.com/5572/91284343-10b5a980-e78c-11ea-91a5-dee5476d32d2.gif)

Notes: 
The preview for the source code is rendered in an `iframe` to be able to load the `contentsCss` (if any) passed in the editor's `config` - without affecting the dialog itself. 