### PR TITLE
feat: add imagespacingbox plugin

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -78,6 +78,9 @@ case "$COMMAND" in
 					node ../support/copyPluginDependencies.js $pluginDir
 				done
 
+				# Copy lang files from image plugin to imagespacingbox
+				cp -r plugins/image/lang plugins/imagespacingbox
+
 				# Generate SVG icons CSS Classes in custom skins
 				skinsWithIcons=$(find skins -maxdepth 2 -mindepth 2 -type f -name icons.json)
 				for iconsFile in $skinsWithIcons ; do
@@ -92,7 +95,7 @@ case "$COMMAND" in
 						--leave-css-unminified --leave-js-unminified --no-ie-checks
 				else
 					dev/builder/build.sh --build-config ../../../support/build-config.js \
-						--no-ie-checks 
+						--no-ie-checks
 				fi
 
 				# Remove old build files.

--- a/plugins/imagespacingbox/plugin.js
+++ b/plugins/imagespacingbox/plugin.js
@@ -1,0 +1,104 @@
+(function () {
+	'use strict';
+	CKEDITOR.plugins.add('imagespacingbox', {
+		init: function (editor) {
+			CKEDITOR.on('dialogDefinition', function (event) {
+				var dialogDefinition = event.data.definition;
+
+				var dialog = event.data.dialog;
+
+				if (dialog.getName() === 'image2') {
+					var infoTab = dialogDefinition.getContents('info');
+
+					if (infoTab.get('spacingBox')) {
+						return;
+					}
+
+					var spacingBox = {
+						children: [
+							{
+								children: [
+									{
+										commit: function (widget) {
+											widget.setData(
+												'hspace',
+												this.getValue()
+											);
+
+											var hspace = widget.data.hspace;
+
+											var imageElement =
+												widget.parts.image;
+
+											if (imageElement && hspace) {
+												imageElement.setStyles({
+													'margin-left':
+														hspace + 'px',
+													'margin-right':
+														hspace + 'px',
+												});
+											}
+										},
+										id: 'hspace',
+										label: editor.lang.image.hSpace,
+										requiredContent:
+											'img{margin-left,margin-right}',
+										setup: function (widget) {
+											this.setValue(widget.data.hspace);
+										},
+										type: 'text',
+										validate: CKEDITOR.dialog.validate.integer(
+											editor.lang.image.validateHSpace
+										),
+									},
+								],
+								type: 'hbox',
+							},
+							{
+								children: [
+									{
+										commit: function (widget) {
+											widget.setData(
+												'vspace',
+												this.getValue()
+											);
+
+											var vspace = widget.data.vspace;
+
+											var imageElement =
+												widget.parts.image;
+
+											if (imageElement && vspace) {
+												imageElement.setStyles({
+													'margin-bottom':
+														vspace + 'px',
+													'margin-top': vspace + 'px',
+												});
+											}
+										},
+										id: 'vspace',
+										label: editor.lang.image.vSpace,
+										requiredContent:
+											'img{margin-top,margin-bottom}',
+										setup: function (widget) {
+											this.setValue(widget.data.vspace);
+										},
+										type: 'text',
+										validate: CKEDITOR.dialog.validate.integer(
+											editor.lang.image.validateVSpace
+										),
+									},
+								],
+								type: 'hbox',
+							},
+						],
+						id: 'spacingBox',
+						type: 'hbox',
+					};
+
+					infoTab.add(spacingBox);
+				}
+			});
+		},
+	});
+})();

--- a/support/build-config.js
+++ b/support/build-config.js
@@ -45,6 +45,7 @@ var CKBUILDER_CONFIG = {
 		format: 1,
 		horizontalrule: 1,
 		image2: 1,
+		imagespacingbox: 1,
 		indentlist: 1,
 		indentblock: 1,
 		justify: 1,


### PR DESCRIPTION
This PR is a follow up on https://github.com/liferay-frontend/liferay-portal/pull/313

The purpose of these changes is adding the possibility for user to add horizontal and vertical space to the image element in editor.
I achieved this by creating `imagespacingbox` plugin which adds 2 additional input fields in `image2` plugin dialog box.
Setting `hspace` value adds horizontal margin, `margin-left` and `margin-right` to image element selected in editor.
Setting `vspace` value adds vertical margin, `margin-left` and `margin-right` to image element selected in editor.

This solves the issue when editing the text next to image, where there was previously no space and allows the user possibility to add custom space replicating functionality we had with `image` plugin.

Additional modifications made in this PR compared to https://github.com/liferay-frontend/liferay-portal/pull/313
- Used `setStyles()` to avoid calling `setStyle()` twice
- Used translation keys from `image` plugin

To test these changes, you can add image to any CKeditor instance in the portal:

For example
Go to
- Build ckeditor with with plugin changes
- Content and Data
- Web Content
- New Basic Web Content
- Upload Image to main editor
- Double click image to open dialog box with `Image properties`
- Add preferred `hspace` or `vspace` values


1. Add 12 hspace value
<img width="1229" alt="1" src="https://user-images.githubusercontent.com/25637907/91545442-548de780-e921-11ea-92bc-89f9bc3f43d9.png">

2. Image with text on the right without horizontal space
<img width="1161" alt="2" src="https://user-images.githubusercontent.com/25637907/91545452-59529b80-e921-11ea-9f1f-506266da2a8b.png">

3. Image with text on the right with applied `hspace` value
<img width="1135" alt="3" src="https://user-images.githubusercontent.com/25637907/91545477-64a5c700-e921-11ea-9523-87fe02e57803.png">

