### PR TITLE
fix: display formatted text in Firefox Preview Source dialog

### DIFF
--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -44,10 +44,7 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 				.getElement();
 			preview.setSize('width', defaultWidth);
 
-			var iframe = this._createContentIframe(preview);
-			var iframeBody = iframe.$.contentDocument.body;
-
-			iframeBody.innerHTML = codeMirrorEditor.getValue();
+			this._createContentIframe(preview);
 
 			codeMirrorEditor.on(
 				'change',
@@ -87,6 +84,57 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 				tabPanel.getSize('height') - (padding.bottom + padding.top);
 
 			var iframe = new CKEDITOR.dom.element('iframe');
+
+			function handleStyles() {
+				var iframeDocument = iframe.$.contentDocument;
+
+				var iframeHead = iframeDocument.head;
+
+				var contentsCss = editor.config.contentsCss;
+
+				if (Array.isArray(contentsCss)) {
+					contentsCss.forEach(function (url) {
+						var link = iframeDocument.createElement('link');
+						link.setAttribute('href', url);
+						link.setAttribute('rel', 'stylesheet');
+
+						iframeHead.appendChild(link);
+					});
+				} else {
+					var link = iframeDocument.createElement('link');
+					link.setAttribute('href', contentsCss);
+					link.setAttribute('rel', 'stylesheet');
+
+					iframeHead.appendChild(link);
+				}
+
+				var direction = editor.config.contentsLangDirection;
+
+				var iframeHtml = iframeDocument.documentElement;
+				iframeHtml.setAttribute('dir', direction);
+				iframeHtml.setAttribute('lang', editor.config.defaultLanguage);
+
+				var iframeBody = iframeDocument.body;
+				iframeBody.classList.add('cke_editable');
+				iframeBody.classList.add('cke_editable_themed');
+				iframeBody.classList.add('cke_contents_' + direction);
+
+				iframeBody.setAttribute('contenteditable', false);
+				iframeBody.setAttribute('spellcheck', false);
+
+				iframeBody.style.background = '#fff';
+			}
+
+			var data = this.codeMirrorEditor.getValue();
+
+			iframe.on('load', function () {
+				var iframeBody = iframe.$.contentDocument.body;
+
+				iframeBody.innerHTML = data;
+
+				handleStyles();
+			});
+
 			parentElement.append(iframe);
 
 			iframe.setAttributes({
@@ -98,43 +146,6 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 				height: height + 'px',
 				width: '99%',
 			});
-
-			var iframeDocument = iframe.$.contentDocument;
-			var iframeHead = iframeDocument.head;
-
-			var contentsCss = editor.config.contentsCss;
-
-			if (Array.isArray(contentsCss)) {
-				contentsCss.forEach(function (url) {
-					var link = iframeDocument.createElement('link');
-					link.setAttribute('href', url);
-					link.setAttribute('rel', 'stylesheet');
-
-					iframeHead.appendChild(link);
-				});
-			} else {
-				var link = iframeDocument.createElement('link');
-				link.setAttribute('href', contentsCss);
-				link.setAttribute('rel', 'stylesheet');
-
-				iframeHead.appendChild(link);
-			}
-
-			var direction = editor.config.contentsLangDirection;
-
-			var iframeHtml = iframeDocument.documentElement;
-			iframeHtml.setAttribute('dir', direction);
-			iframeHtml.setAttribute('lang', editor.config.defaultLanguage);
-
-			var iframeBody = iframeDocument.body;
-			iframeBody.classList.add('cke_editable');
-			iframeBody.classList.add('cke_editable_themed');
-			iframeBody.classList.add('cke_contents_' + direction);
-
-			iframeBody.setAttribute('contenteditable', false);
-			iframeBody.setAttribute('spellcheck', false);
-
-			iframeBody.style.background = '#fff';
 
 			return iframe;
 		},

--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -84,56 +84,7 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 				tabPanel.getSize('height') - (padding.bottom + padding.top);
 
 			var iframe = new CKEDITOR.dom.element('iframe');
-
-			function handleStyles() {
-				var iframeDocument = iframe.$.contentDocument;
-
-				var iframeHead = iframeDocument.head;
-
-				var contentsCss = editor.config.contentsCss;
-
-				if (Array.isArray(contentsCss)) {
-					contentsCss.forEach(function (url) {
-						var link = iframeDocument.createElement('link');
-						link.setAttribute('href', url);
-						link.setAttribute('rel', 'stylesheet');
-
-						iframeHead.appendChild(link);
-					});
-				} else {
-					var link = iframeDocument.createElement('link');
-					link.setAttribute('href', contentsCss);
-					link.setAttribute('rel', 'stylesheet');
-
-					iframeHead.appendChild(link);
-				}
-
-				var direction = editor.config.contentsLangDirection;
-
-				var iframeHtml = iframeDocument.documentElement;
-				iframeHtml.setAttribute('dir', direction);
-				iframeHtml.setAttribute('lang', editor.config.defaultLanguage);
-
-				var iframeBody = iframeDocument.body;
-				iframeBody.classList.add('cke_editable');
-				iframeBody.classList.add('cke_editable_themed');
-				iframeBody.classList.add('cke_contents_' + direction);
-
-				iframeBody.setAttribute('contenteditable', false);
-				iframeBody.setAttribute('spellcheck', false);
-
-				iframeBody.style.background = '#fff';
-			}
-
-			var data = this.codeMirrorEditor.getValue();
-
-			iframe.on('load', function () {
-				var iframeBody = iframe.$.contentDocument.body;
-
-				iframeBody.innerHTML = data;
-
-				handleStyles();
-			});
+			iframe.on('load', this._handleIframeLoaded.bind(this));
 
 			parentElement.append(iframe);
 
@@ -162,6 +113,54 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 				var iframeBody = iframeDocument.body;
 				iframeBody.innerHTML = newData;
 			}
+		},
+
+		_handleIframeLoaded: function (event) {
+			var data = this.codeMirrorEditor.getValue();
+
+			var iframe = event.sender;
+
+			var iframeBody = iframe.$.contentDocument.body;
+
+			iframeBody.innerHTML = data;
+
+			var iframeDocument = iframe.$.contentDocument;
+
+			var iframeHead = iframeDocument.head;
+
+			var contentsCss = editor.config.contentsCss;
+
+			if (Array.isArray(contentsCss)) {
+				contentsCss.forEach(function (url) {
+					var link = iframeDocument.createElement('link');
+					link.setAttribute('href', url);
+					link.setAttribute('rel', 'stylesheet');
+
+					iframeHead.appendChild(link);
+				});
+			} else {
+				var link = iframeDocument.createElement('link');
+				link.setAttribute('href', contentsCss);
+				link.setAttribute('rel', 'stylesheet');
+
+				iframeHead.appendChild(link);
+			}
+
+			var direction = editor.config.contentsLangDirection;
+
+			var iframeHtml = iframeDocument.documentElement;
+			iframeHtml.setAttribute('dir', direction);
+			iframeHtml.setAttribute('lang', editor.config.defaultLanguage);
+
+			var iframeBody = iframeDocument.body;
+			iframeBody.classList.add('cke_editable');
+			iframeBody.classList.add('cke_editable_themed');
+			iframeBody.classList.add('cke_contents_' + direction);
+
+			iframeBody.setAttribute('contenteditable', false);
+			iframeBody.setAttribute('spellcheck', false);
+
+			iframeBody.style.background = '#fff';
 		},
 
 		contents: [

--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -88,10 +88,7 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 
 			parentElement.append(iframe);
 
-			iframe.setAttributes({
-				class: 'cke_wysiwyg_frame cke_reset',
-				frameborder: 0,
-			});
+			iframe.setAttribute('frameborder', 0);
 
 			iframe.setStyles({
 				height: height + 'px',
@@ -119,6 +116,9 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 			var data = this.codeMirrorEditor.getValue();
 
 			var iframe = event.sender;
+
+			iframe.addClass('cke_wysiwyg_frame');
+			iframe.addClass('cke_reset');
 
 			var iframeBody = iframe.$.contentDocument.body;
 


### PR DESCRIPTION
This PR is a fix for [LPS-120763](https://issues.liferay.com/browse/LPS-120763) - `"CKEditor - Formatted text doesn't display in Preview Source dialog on Firefox"` bug in `codemirror` plugin.

As described in the ticket, the issue happened when editing text and opening Source dialog in Firefox.
The added text would't appear in the code preview area.
This cause of this issue is that in Firefox, the frame's content is not recognised if there is no initial content set. 
To solve this we need to trigger a `page load` and then set `innerHtml` to `iFrame` preview.

--------------
To test this:
1. Build CKEditor with this change
2. Access to portal on Firefox browser.
3. Go to Web Content.
4. Add a content.
5. In content field, click Source button in ckeditor toolbar to go to source view.
6. Type "test" or <p>test</p>
7. Click the Expand icon next to the Source button to preview source.

Old behaviour
![Firefox-web content source preview](https://user-images.githubusercontent.com/25637907/93210963-daeb5b80-f760-11ea-99e5-14bfd3fd63db.gif)

New behaviour
![after](https://user-images.githubusercontent.com/25637907/93211643-cfe4fb00-f761-11ea-98c6-7e0b8bf0ce8d.gif)

