### PR TITLE
fix: enable line wrapping in codemirror plugin

### DIFF
--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -33,7 +33,14 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 
 			var defaultWidth = size.width / 2 - padding;
 
-			codeMirrorEditor.setSize(defaultWidth, null);
+			var tabPanel = this._getTabPanel();
+			var tabPanelPadding = this._getTabPanelPadding();
+
+			var defaultHeight =
+				tabPanel.getSize('height') -
+				(tabPanelPadding.bottom + tabPanelPadding.top);
+
+			codeMirrorEditor.setSize(defaultWidth, defaultHeight);
 
 			var editor = dialog.getParentEditor();
 
@@ -56,32 +63,12 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 			var dialog = this.dialog;
 			var editor = dialog.getParentEditor();
 
-			var mainElement = dialog.getContentElement('main').getElement();
-
-			var tabPanel = mainElement.getAscendant(function (el) {
-				return (
-					el.getName() === 'div' &&
-					el.getAttribute('role') === 'tabpanel'
-				);
-			});
-
-			var tabPanelParent = tabPanel.getParent();
-
-			var padding = {
-				bottom:
-					parseInt(
-						tabPanelParent.getComputedStyle('padding-bottom'),
-						10
-					) || 0,
-				top:
-					parseInt(
-						tabPanelParent.getComputedStyle('padding-top'),
-						10
-					) || 0,
-			};
+			var tabPanel = this._getTabPanel();
+			var tabPanelPadding = this._getTabPanelPadding();
 
 			var height =
-				tabPanel.getSize('height') - (padding.bottom + padding.top);
+				tabPanel.getSize('height') -
+				(tabPanelPadding.bottom + tabPanelPadding.top);
 
 			var iframe = new CKEDITOR.dom.element('iframe');
 			iframe.on('load', this._handleIframeLoaded.bind(this));
@@ -161,6 +148,53 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 			iframeBody.setAttribute('spellcheck', false);
 
 			iframeBody.style.background = '#fff';
+
+			return iframe;
+		},
+
+		_getTabPanel: function () {
+			var mainElement = this.dialog
+				.getContentElement('main')
+				.getElement();
+
+			return mainElement.getAscendant(function (el) {
+				return (
+					el.getName() === 'div' &&
+					el.getAttribute('role') === 'tabpanel'
+				);
+			});
+		},
+
+		_getTabPanelPadding: function () {
+			var tabPanel = this._getTabPanel();
+			var tabPanelParent = tabPanel.getParent();
+
+			return {
+				bottom:
+					parseInt(
+						tabPanelParent.getComputedStyle('padding-bottom'),
+						10
+					) || 0,
+				top:
+					parseInt(
+						tabPanelParent.getComputedStyle('padding-top'),
+						10
+					) || 0,
+			};
+		},
+
+		_handleCodeMirrorChange: function () {
+			var newData = this.codeMirrorEditor.getValue();
+			var preview = this.dialog
+				.getContentElement('main', 'preview')
+				.getElement();
+
+			var iframe = preview.findOne('iframe');
+			if (iframe && iframe.$) {
+				var iframeDocument = iframe.$.contentDocument;
+				var iframeBody = iframeDocument.body;
+				iframeBody.innerHTML = newData;
+			}
 		},
 
 		contents: [

--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -19,6 +19,7 @@
 					textarea.$,
 					{
 						lineNumbers: true,
+						lineWrapping: true,
 						mode: 'text/html',
 					}
 				);

--- a/plugins/codemirror/skins/default.css
+++ b/plugins/codemirror/skins/default.css
@@ -11,6 +11,10 @@ a.cke_button__source.cke_button_off + a.cke_button__expand.cke_button_disabled {
 	font-size: 13px;
 }
 
+.cke_reset_all .CodeMirror-scroll * {
+	white-space: pre-wrap;
+}
+
 .cke_dialog .code_preview {
 	border-left: 1px solid #bcbcbc;
 	overflow-x: auto;


### PR DESCRIPTION
This solves the issue described in [LPS-120594](https://issues.liferay.com/browse/LPS-120549), where
occasionally the editor's source mode (now handled by the `codemirror`
plugin) grows depending on the text that is in the editor.

Here's a screenshot of what it looked like before this change:

![](https://user-images.githubusercontent.com/5572/93472140-90024d00-f8f4-11ea-9447-eda457654256.png)

And here's a screenshot of what it looks like after this change:

![](https://user-images.githubusercontent.com/5572/93472183-9db7d280-f8f4-11ea-80a6-87eac423285e.png)

**Test plan**:

- Fetch this branch, and build `liferay-ckeditor` with `./ck.sh build`
- Use the previously built `liferay-ckeditor` in DXP. ([Instructions](https://github.com/liferay/liferay-ckeditor#testing-in-liferay-portal))
- In DXP, from the global menu, navigate to "Instance Settings > Email" and once the page is loaded, click on the "Source" button 

Another thought I had, is that if we were using ES6 in CKEDITOR plugins, 
we could possibly add the CodeMirror options in a separate file to make sure
both editor (the one in `codemirror` plugin and the one in `codemirrordialog`) 
always have the same options - but I'm not ready yet (and who knows
what could happen if we decided to build CKEDITOR with ES6)