### PR TITLE
fix: modify calculation for dialog defaultWidth which caused visual bug

### DIFF
--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -29,7 +29,9 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 				}
 			));
 
-			var defaultWidth = size.width * 0.5 - 10;
+			var padding = 40;
+
+			var defaultWidth = size.width / 2 - padding;
 
 			codeMirrorEditor.setSize(defaultWidth, null);
 


### PR DESCRIPTION
This PR fixes an issue described in https://issues.liferay.com/browse/LPS-120758 ,visual bug in `Chrome` (scrollbar) and in `Firefox` (whitespace) in Source dialog box.
This issue was caused by `CodeMirror` plugin line number width not included in dialog size calculation.

To test this fix:
1. Build CKEditor with this change
2. Access to portal.
3. Go to Web Content.
4. Add a content.
5. In content field, click Source button in ckeditor toolbar to go to source view.
6. Type any text
7. Click the Expand icon next to the Source button to preview source dialog.

Before Chrome
![beforechrome](https://user-images.githubusercontent.com/25637907/93473664-909be300-f8f6-11ea-892b-19b9a64c5448.png)

Before Firefox
![beforefirefox](https://user-images.githubusercontent.com/25637907/93473677-95609700-f8f6-11ea-88de-46a250422890.png)

After Chrome
<img width="1512" alt="afterchrome" src="https://user-images.githubusercontent.com/25637907/93473696-9abde180-f8f6-11ea-8bf0-586dad6565e2.png">

After Firefox
<img width="1519" alt="afterfirefox" src="https://user-images.githubusercontent.com/25637907/93473732-a5787680-f8f6-11ea-9801-b2fca081aba1.png">
