### PR TITLE
fix: add condition for buttoncolor so scrollbar will not be removed

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From bb8157502a44ede7c8b1806ef63fcdf3554e8089 Mon Sep 17 00:00:00 2001
+From 113849fd54d137f21f488b0ffe06642e93d3aa6f Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 30fce10a6a6b640ab317ad7cb96a540940afdcd2 Mon Sep 17 00:00:00 2001
+From d8d4544d0667e2c48fc684ac81c4550d4f0709d7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From f22231335a80630b23d7af98508585cd2650d2c3 Mon Sep 17 00:00:00 2001
+From f52af46b27953a2d575516655a19206009dfa056 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From a966d5de4173b0b480c988a9c578577bd7170526 Mon Sep 17 00:00:00 2001
+From 8f0168c70faadce75e3e13dac7f78d85a53762fa Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 11801b3f4995cd1799ec00ecef35252898c54757 Mon Sep 17 00:00:00 2001
+From 4df6112d843a19ebf6ee2283245b168a7eb70d37 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From a62acb27ffd532f3c3bb00e9ad727b62a95e9af6 Mon Sep 17 00:00:00 2001
+From 59c3aada3ea965a0cb0332d3e95f4ddbab4797dd Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-121472-Create-condition-for-buttoncolor-scrollba.patch
+++ b/patches/0007-LPS-121472-Create-condition-for-buttoncolor-scrollba.patch
@@ -1,0 +1,24 @@
+From 986463b492d4549ba860aa7e832f41a7789b528e Mon Sep 17 00:00:00 2001
+From: Fortunato Maldonado <fortunato.maldonado@liferay.com>
+Date: Tue, 29 Sep 2020 08:21:24 -0700
+Subject: [PATCH] LPS-121472 Create condition for buttoncolor scrollbar
+
+---
+ plugins/colorbutton/plugin.js | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/plugins/colorbutton/plugin.js b/plugins/colorbutton/plugin.js
+index fa0a582c2..a57089fa6 100644
+--- a/plugins/colorbutton/plugin.js
++++ b/plugins/colorbutton/plugin.js
+@@ -187,7 +187,9 @@ CKEDITOR.plugins.add( 'colorbutton', {
+ 						commandName: commandName
+ 					} ) );
+ 					// The block should not have scrollbars (https://dev.ckeditor.com/ticket/5933, https://dev.ckeditor.com/ticket/6056)
+-					block.element.getDocument().getBody().setStyle( 'overflow', 'hidden' );
++					if (block.element.getDocument().getBody().hasClass('cke_ltr')) {
++						block.element.getDocument().getBody().setStyle('overflow', 'hidden');
++					}
+ 
+ 					CKEDITOR.ui.fire( 'ready', this );
+ 


### PR DESCRIPTION
https://github.com/liferay/liferay-ckeditor/issues/134
https://issues.liferay.com/browse/LPS-121472

A scrollbar will disappear whenever AlloyEditor contains the Text Color button and it is being used.

I found that CKEditor uses this behavior [`onBlock` ](https://github.com/ckeditor/ckeditor4/blob/major/plugins/colorbutton/plugin.js#L193) for its text color block. I added a condition to check for the class `cke_ltr` which is used only in CKEditor for the Text Color block and not in AlloyEditor. This will prevent any unnecesary changes to CKEditor and will not remove the scrollbar when it is used in AlloyEditor.

Please let me know if there are any questions, comments, or if I need to change any process that I did.
Thank you.