### PR TITLE
fix: make text wrap in codemirror plugin

### DIFF
--- a/plugins/codemirror/skins/default.css
+++ b/plugins/codemirror/skins/default.css
@@ -15,6 +15,11 @@ a.cke_button__source.cke_button_off + a.cke_button__expand.cke_button_disabled {
 	white-space: pre-wrap;
 }
 
+.cke_reset .CodeMirror-wrap pre.CodeMirror-line {
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
 .cke_dialog .code_preview {
 	border-left: 1px solid #bcbcbc;
 	overflow-x: auto;


### PR DESCRIPTION
In [`5de7cdb`](https://github.com/liferay/liferay-ckeditor/commit/5de7cdbed7e7e9b50cd5e77d5dc020e137b104a3) and [`1783acf`](https://github.com/liferay/liferay-ckeditor/commit/1783acf68ee470fa79619462e8c2df6f9ec39d4a)  we intended to fix text wrapping in the
`codemirror` (source view) plugin but this was apparently missing 

**Test plan**:
- Fetch this branch and build `liferay-ckeditor` with

    ```sh
    ./ck.sh build
    ```

- Use the previously built version of `liferay-ckeditor` in DXP
- Deploy the `frontend-editor-ckeditor-web` OSGi module
- Navigate to **Instance Settings** > **Email**
- Assert that the editors wrap text correctly

**Before**

![before](https://user-images.githubusercontent.com/5572/95835355-65ae7e80-0d3e-11eb-9ea4-ac215749cfc3.png)

**After**

![after](https://user-images.githubusercontent.com/5572/95835376-6cd58c80-0d3e-11eb-9056-fcce6691a819.png)
