### PR TITLE
fix: LPS-124728 Avoid using unsupported APIs in IE11

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From bb8157502a44ede7c8b1806ef63fcdf3554e8089 Mon Sep 17 00:00:00 2001
+From 91f78cf4170523fd964702ea03c65644d18a14c0 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 30fce10a6a6b640ab317ad7cb96a540940afdcd2 Mon Sep 17 00:00:00 2001
+From 3477710ac52fa0d83ee19d0c3f63749983740f29 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From f22231335a80630b23d7af98508585cd2650d2c3 Mon Sep 17 00:00:00 2001
+From 52b602de7eff89f491118c43158bae978a9a8199 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From a966d5de4173b0b480c988a9c578577bd7170526 Mon Sep 17 00:00:00 2001
+From 9a9193afb43cf7637f7bcc2513234fee997e936f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 11801b3f4995cd1799ec00ecef35252898c54757 Mon Sep 17 00:00:00 2001
+From 60edaff5b029f76188566dd60b06458624b84e2e Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From a62acb27ffd532f3c3bb00e9ad727b62a95e9af6 Mon Sep 17 00:00:00 2001
+From f6b486035bc88ebc406644c62db53914f5bb7605 Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,0 +1,61 @@
+From d0bf70988e63c2c84076d7418eb6cfe0edc438de Mon Sep 17 00:00:00 2001
+From: Julien Castelain <julien.castelain@liferay.com>
+Date: Mon, 21 Dec 2020 09:12:53 +0100
+Subject: [PATCH] LPS-124728 Avoid breaking IE11
+
+IE11 Doesn't support URL, URLSearchParams and Object.entries
+In theory though we have a pollyfill for these but it seems that
+they aren't loaded when getUrl is executed.
+---
+ core/ckeditor_base.js | 30 ++++++++++++++++++------------
+ 1 file changed, 18 insertions(+), 12 deletions(-)
+
+diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
+index 6d9fcbc03..59b3e4a0b 100644
+--- a/core/ckeditor_base.js
++++ b/core/ckeditor_base.js
+@@ -171,26 +171,32 @@ if ( !window.CKEDITOR ) {
+ 			 * @returns {String} The full URL.
+ 			 */
+ 			getUrl: function( resource ) {
+-				var resourceUrl = resource.startsWith(this.basePath)
+-					? new URL(resource)
+-					: new URL(this.basePath + resource);
++				function set(key, value) {
++					if (!resource.match(new RegExp('[&?]' + key + '\\b'))) {
++						resource += (resource.indexOf('?') >= 0 ? '&' : '?') + key + '=' + value;
++					}
++				}
+ 
+-				if (!resourceUrl.toString().endsWith('/')) {
+-					if (this.timestamp && !resourceUrl.searchParams.has('t')) {
+-						resourceUrl.searchParams.set('t', this.timestamp);
++				// If this is not a full or absolute path.
++				if (resource.indexOf(':/') === -1 && resource.indexOf('/') !== 0) {
++					resource = this.basePath + resource;
++				}
++
++				if (resource.charAt(resource.length - 1) !== '/') {
++					if (this.timestamp) {
++						set('t', this.timestamp);
+ 					}
+ 
+-					Object.entries(CKEDITOR.ADDITIONAL_RESOURCE_PARAMS).forEach(function(entries) {
+-						var key = entries[0];
+-						var value = entries[1];
++					Object.keys(CKEDITOR.ADDITIONAL_RESOURCE_PARAMS).forEach(function(key) {
++						var value = CKEDITOR.ADDITIONAL_RESOURCE_PARAMS[key];
+ 
+-						if (!resourceUrl.searchParams.has(key) && !(resourceUrl.toString().includes('.css') && key === 'languageId')) {
+-							resourceUrl.searchParams.set(key, value);
++						if (!/\.css$/.test(resource) || key !== 'languageId') {
++							set(key, value);
+ 						}
+ 					});
+ 				}
+ 
+-				return resourceUrl.toString();
++				return resource;
+ 			},
+ 
+ 			/**


### PR DESCRIPTION
We were using `URL`, `URLSearchParams` and `Object.entries`, 
which aren't supported in IE11 . In theory we have polyfills for these 
but apparently when `getUrl` is executed these polyfills aren't loaded yet.

So this patch reverts a previous patch and adds more .

Tested agaisn't [LPS-124728](https://issues.liferay.com/browse/LPS-124728) and [LPS-112982](https://issues.liferay.com/browse/LPS-112982)