### PR TITLE
fix: LPS-125441 CKEditor font size selector flickers on mouse over

### DIFF
--- a/skins/moono-lexicon/richcombo.css
+++ b/skins/moono-lexicon/richcombo.css
@@ -196,8 +196,8 @@ a.cke_combo_button {
 .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:focus,
 .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active {
 	/* If first combo in a row do not use negative margin so it is aligned with other rows on hover. */
-	padding: 0;
-	margin: 0;
+	padding: 6px 18px;
+	margin: 0 4px 0 0;
 }
 
 .cke_hc


### PR DESCRIPTION
Hey,

[LPS-125441](https://issues.liferay.com/browse/LPS-125441)
Our ckeditor skin had a flickering, as the focus and active state of the elements did not contain the necessary padding and margin values. This issue is not reproducible on master due to our toolbar change, however on 7.2.x where the toolbar still holds the same plugins, it is reproducible.

Please review my changes