### PR TITLE
fix: Make table properties visible

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From 91f78cf4170523fd964702ea03c65644d18a14c0 Mon Sep 17 00:00:00 2001
+From 5f6ea3154ececf568fed6168df109982723bfb4c Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 3477710ac52fa0d83ee19d0c3f63749983740f29 Mon Sep 17 00:00:00 2001
+From a94350e2a5272963fc9729b9dab1712dc1dadee5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From 52b602de7eff89f491118c43158bae978a9a8199 Mon Sep 17 00:00:00 2001
+From aa5d0c610dfc7131cf4405e706c215208774bc01 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From 9a9193afb43cf7637f7bcc2513234fee997e936f Mon Sep 17 00:00:00 2001
+From 754ecf387f47aaacd4265afd31ac148c6de2993f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 60edaff5b029f76188566dd60b06458624b84e2e Mon Sep 17 00:00:00 2001
+From 65cb793bb46a4d386e72052d69e08d1232da0e95 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From f6b486035bc88ebc406644c62db53914f5bb7605 Mon Sep 17 00:00:00 2001
+From 9b636c82c8c887d6ecd56545c9599f178e287ebf Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From d0bf70988e63c2c84076d7418eb6cfe0edc438de Mon Sep 17 00:00:00 2001
+From 44b0f11cf66dc9380f9f165e671894185f5f1654 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,0 +1,41 @@
+From 5235ff3c5b1102541f98795e0743cce125addc14 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
+Date: Fri, 8 Jan 2021 10:58:23 +0100
+Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,
+ Cell padding, Border size
+
+---
+ plugins/table/dialogs/table.js | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/plugins/table/dialogs/table.js b/plugins/table/dialogs/table.js
+index c3b9531bd..a9ba49437 100755
+--- a/plugins/table/dialogs/table.js
++++ b/plugins/table/dialogs/table.js
+@@ -342,7 +342,7 @@
+ 							// Avoid setting border which will then disappear.
+ 							'default': editor.filter.check( 'table[border]' ) ? 1 : 0,
+ 							label: editor.lang.table.border,
+-							controlStyle: 'width:3em',
++							controlStyle: 'width:5em',
+ 							validate: CKEDITOR.dialog.validate.number( editor.lang.table.invalidBorder ),
+ 							setup: function( selectedTable ) {
+ 								this.setValue( selectedTable.getAttribute( 'border' ) || '' );
+@@ -438,7 +438,7 @@
+ 							type: 'text',
+ 							id: 'txtCellSpace',
+ 							requiredContent: 'table[cellspacing]',
+-							controlStyle: 'width:3em',
++							controlStyle: 'width:5em',
+ 							label: editor.lang.table.cellSpace,
+ 							'default': editor.filter.check( 'table[cellspacing]' ) ? 1 : 0,
+ 							validate: CKEDITOR.dialog.validate.number( editor.lang.table.invalidCellSpacing ),
+@@ -456,7 +456,7 @@
+ 							type: 'text',
+ 							id: 'txtCellPad',
+ 							requiredContent: 'table[cellpadding]',
+-							controlStyle: 'width:3em',
++							controlStyle: 'width:5em',
+ 							label: editor.lang.table.cellPad,
+ 							'default': editor.filter.check( 'table[cellpadding]' ) ? 1 : 0,
+ 							validate: CKEDITOR.dialog.validate.number( editor.lang.table.invalidCellPadding ),


### PR DESCRIPTION
On the table Properties modal window the following fields value are not visible

Border size
Cell padding
Cell spacing
The .cke_dialog_ui_labeled_content style should be width: 5em; instead of the width: 3em;

Fixes #149

**Before**

![before](https://user-images.githubusercontent.com/5572/104009228-fc0e0700-51aa-11eb-800a-4fc13dc6c3e3.png)

**After**

![after](https://user-images.githubusercontent.com/5572/104009245-03351500-51ab-11eb-9b9a-28c4c1c17118.png)
