### PR TITLE
fix: update codemirror plugin

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -13,7 +13,10 @@
 				var textarea = contentsSpace
 					.getDocument()
 					.createElement('textarea');
+
 				contentsSpace.append(textarea);
+
+				editor.editable(new codeMirrorEditable(editor, textarea));
 
 				instance.codeMirrorEditor = CodeMirror.fromTextArea(
 					textarea.$,
@@ -140,6 +143,41 @@
 							: CKEDITOR.TRISTATE_OFF
 					);
 			});
+		},
+	});
+
+	var codeMirrorEditable = CKEDITOR.tools.createClass({
+		base: CKEDITOR.editable,
+
+		proto: {
+			setData: function (data) {
+				this.setValue(data);
+				this.value = 'ready';
+				this.editor.fire('dataReady');
+			},
+
+			getData: function () {
+				return this.getValue();
+			},
+
+			// Insertions are not supported in source editable.
+			insertHtml: function () {},
+			insertElement: function () {},
+			insertText: function () {},
+
+			// Read-only support for textarea.
+			setReadOnly: function (isReadOnly) {
+				this[(isReadOnly ? 'set' : 'remove') + 'Attribute'](
+					'readOnly',
+					'readonly'
+				);
+			},
+
+			detach: function () {
+				codeMirrorEditable.baseProto.detach.call(this);
+				this.clearCustomData();
+				this.remove();
+			},
 		},
 	});
 })();


### PR DESCRIPTION
Add an editable to the codemirror plugin, so that it also dispatches
the "change" event in source mode

This was copied directly from the original `sourcearea` plugin,
from [here](https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/plugins/sourcearea/plugin.js#L48) and [here](https://github.com/ckeditor/ckeditor4/blob/eb2d11644a796cd13cd047cd55541430359f9317/plugins/sourcearea/plugin.js#L103-L133)

**Preview**

![](https://user-images.githubusercontent.com/5572/109955129-6ee6ba80-7ce2-11eb-8f9f-bf7182c200d8.gif)


Fixes #153