### PR TITLE
fix: remove css classes as well when changing style

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From 5f6ea3154ececf568fed6168df109982723bfb4c Mon Sep 17 00:00:00 2001
+From 1384a39e13ba43ee01d1b8de799e5197a7edf239 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From a94350e2a5272963fc9729b9dab1712dc1dadee5 Mon Sep 17 00:00:00 2001
+From a61fbca15e5d58e66f9443cec49691bd51b5ec08 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From aa5d0c610dfc7131cf4405e706c215208774bc01 Mon Sep 17 00:00:00 2001
+From dc41b4d0bbee68f861df10e7bda3735bc7eab082 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From 754ecf387f47aaacd4265afd31ac148c6de2993f Mon Sep 17 00:00:00 2001
+From 65d73e94a2fbb061048058dabdb76331d27fbffc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 65cb793bb46a4d386e72052d69e08d1232da0e95 Mon Sep 17 00:00:00 2001
+From e2289deb4c4f68b34e2975d417077b6d0543d52f Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From 9b636c82c8c887d6ecd56545c9599f178e287ebf Mon Sep 17 00:00:00 2001
+From de2970b1f84351d7f6158a95f37a54b9c01e76cf Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From 44b0f11cf66dc9380f9f165e671894185f5f1654 Mon Sep 17 00:00:00 2001
+From e16d379c7e35a1306b4b734aa49cd21cd6d555b6 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From 5235ff3c5b1102541f98795e0743cce125addc14 Mon Sep 17 00:00:00 2001
+From 3c5eea93c086cb3af9157ebde1f7fa90b9d386e8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,

--- a/patches/0009-LPS-127732-remove-css-classes-as-well-when-changing-.patch
+++ b/patches/0009-LPS-127732-remove-css-classes-as-well-when-changing-.patch
@@ -1,0 +1,22 @@
+From 213029994cdb8f07eb8299d94a94aeab314c958b Mon Sep 17 00:00:00 2001
+From: Norbert Nemeth <norbert.nemeth@liferay.com>
+Date: Thu, 11 Mar 2021 16:09:52 +0100
+Subject: [PATCH] LPS-127732 remove css classes as well when changing style
+
+---
+ plugins/removeformat/plugin.js | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/removeformat/plugin.js b/plugins/removeformat/plugin.js
+index e1e41bb3e..8aa04768a 100644
+--- a/plugins/removeformat/plugin.js
++++ b/plugins/removeformat/plugin.js
+@@ -35,7 +35,7 @@ CKEDITOR.plugins.removeformat = {
+ 					range;
+ 
+ 				while ( ( range = iterator.getNextRange() ) ) {
+-					range.enlarge( CKEDITOR.ENLARGE_INLINE );
++					range.enlarge( CKEDITOR.ENLARGE_ELEMENT );
+ 
+ 					// Bookmark the range so we can re-select it after processing.
+ 					var bookmark = range.createBookmark(),


### PR DESCRIPTION
Hey,
[LPS-127732](https://issues.liferay.com/browse/LPS-127732) (we can use this to update the ckeditor version in Liferay),

I modified the solution and generated a patch as suggested in https://github.com/liferay/liferay-ckeditor/pull/155

Please review it,

Thanks