### PR TITLE
fix: use CKEditor's `editable` to sync content between editor and dialogs

### DIFF
--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -44,7 +44,7 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 
 			var editor = dialog.getParentEditor();
 
-			codeMirrorEditor.setValue(editor.getData(true));
+			codeMirrorEditor.setValue(editor.getData());
 
 			var preview = dialog
 				.getContentElement('main', 'preview')

--- a/plugins/codemirror/dialogs/codemirrordialog.js
+++ b/plugins/codemirror/dialogs/codemirrordialog.js
@@ -236,8 +236,9 @@ CKEDITOR.dialog.add('codemirrordialog', function (editor) {
 
 			if (newData !== oldData) {
 				editor.setData(newData);
-				editor.setMode('wysiwyg');
 			}
+
+			editor.setMode('wysiwyg');
 		},
 
 		onShow: function () {

--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -156,7 +156,7 @@
 		proto: {
 			setData: function (data) {
 				this.setValue(data);
-				this.value = 'ready';
+				this.status = 'ready';
 				this.editor.fire('dataReady');
 			},
 

--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -16,8 +16,6 @@
 
 				contentsSpace.append(textarea);
 
-				editor.editable(new codeMirrorEditable(editor, textarea));
-
 				instance.codeMirrorEditor = CodeMirror.fromTextArea(
 					textarea.$,
 					{
@@ -28,6 +26,12 @@
 				);
 
 				var oldData = editor.getData(1);
+
+				var editable = editor.editable(
+					new codeMirrorEditable(editor, textarea)
+				);
+
+				editable.setData(oldData);
 
 				instance.codeMirrorEditor.setValue(oldData);
 


### PR DESCRIPTION
By using the `editable` function, we make sure the editor's content
is not lost when switching from wysiwyg to source mode, and
when opening the "preview" dialog.

**Before**

![](https://user-images.githubusercontent.com/5572/111985807-675e4880-8b0d-11eb-8ede-f5491b2b13a4.gif)

**After**

![](https://user-images.githubusercontent.com/5572/111985828-6decc000-8b0d-11eb-8490-36d0a333e201.gif)
