### PR TITLE
fix: initialize codemirror with the editor data and update it on data ready

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -49,6 +49,16 @@
 					instance._handleEditorResize.bind(instance)
 				);
 
+				editor.on('dataReady', function (event) {
+					var newData = event.data;
+
+					var oldData = instance.codeMirrorEditor.getValue();
+
+					if (newData && newData !== oldData) {
+						instance.codeMirrorEditor.setValue(newData);
+					}
+				});
+
 				editor.fire('ariaWidget', this);
 
 				callback();
@@ -156,8 +166,8 @@
 		proto: {
 			setData: function (data) {
 				this.setValue(data);
-				this.status = 'ready';
-				this.editor.fire('dataReady');
+				this.value = 'ready';
+				this.editor.fire('dataReady', data);
 			},
 
 			getData: function () {

--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -166,7 +166,7 @@
 		proto: {
 			setData: function (data) {
 				this.setValue(data);
-				this.value = 'ready';
+				this.status = 'ready';
 				this.editor.fire('dataReady', data);
 			},
 


### PR DESCRIPTION
This is a follow up for #160, to fix [LPS-128735](https://issues.liferay.com/browse/LPS-128735), with the change I suggested [here](https://github.com/liferay/liferay-ckeditor/pull/160#discussion_r609864815)


