### PR TITLE
fix: LPS-127014 Add balloontoolbar missing style

### DIFF
--- a/plugins/balloontoolbar/skins/moono-lexicon/balloontoolbar.css
+++ b/plugins/balloontoolbar/skins/moono-lexicon/balloontoolbar.css
@@ -3,6 +3,26 @@ Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 
+.cke_balloon.cke_balloontoolbar {
+	background: white;
+	border-color: #e7e7ed;
+	box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.cke_balloon.cke_balloontoolbar
+	.cke_balloon_triangle_outer.cke_balloon_triangle_bottom,
+.cke_balloon.cke_balloontoolbar
+	.cke_balloon_triangle_outer.cke_balloon_triangle_top {
+	border-color: #e7e7ed transparent;
+}
+
+.cke_balloon.cke_balloontoolbar
+	.cke_balloon_triangle_inner.cke_balloon_triangle_bottom,
+.cke_balloon.cke_balloontoolbar
+	.cke_balloon_triangle_inner.cke_balloon_triangle_top {
+	border-color: white transparent;
+}
+
 .cke_balloon.cke_balloontoolbar span:last-child a:last-child::after,
 .cke_balloon.cke_balloontoolbar span:last-child a:last-child:hover::after,
 .cke_balloon.cke_balloontoolbar span:last-child::after {


### PR DESCRIPTION
This PR add the missing styles for the balloontoolbar

**Before**
![](https://user-images.githubusercontent.com/5572/115399350-6261e700-a1e8-11eb-8185-aacbc3fb2965.png)

**After**
![](https://user-images.githubusercontent.com/5572/115399379-6b52b880-a1e8-11eb-8266-069238725601.png)

