### PR TITLE
feat: patch the `balloontoolbar` and `balloonpanel` plugins

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From 5f6ea3154ececf568fed6168df109982723bfb4c Mon Sep 17 00:00:00 2001
+From 2f3da16693289010ef5e123a88b9cbb61d55fc00 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From a94350e2a5272963fc9729b9dab1712dc1dadee5 Mon Sep 17 00:00:00 2001
+From 3e2be670e31e10d957d975fa4d902a016f7931fa Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From aa5d0c610dfc7131cf4405e706c215208774bc01 Mon Sep 17 00:00:00 2001
+From b7ffd96bfdf5486b558db20080570bb4a6109122 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From 754ecf387f47aaacd4265afd31ac148c6de2993f Mon Sep 17 00:00:00 2001
+From 217abf2c6f97cfffcf95f72c567889077d5dbdb9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 65cb793bb46a4d386e72052d69e08d1232da0e95 Mon Sep 17 00:00:00 2001
+From 66536494611f0e0d854b9988a30ae9446fb1342f Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From 9b636c82c8c887d6ecd56545c9599f178e287ebf Mon Sep 17 00:00:00 2001
+From 9a1ba063b9706942cd1b2984dccc5a59b97bd055 Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From 44b0f11cf66dc9380f9f165e671894185f5f1654 Mon Sep 17 00:00:00 2001
+From 6ec13327a3b4be619f7919a07e50cd0d4b505e4e Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From 5235ff3c5b1102541f98795e0743cce125addc14 Mon Sep 17 00:00:00 2001
+From 22785b1bd551c176deb6af98651634ea8a8fdda7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,

--- a/patches/0009-LPS-130835-Patch-balloontoolbar-and-balloonpanel-plu.patch
+++ b/patches/0009-LPS-130835-Patch-balloontoolbar-and-balloonpanel-plu.patch
@@ -1,0 +1,407 @@
+From ea7d69b2df1f2500d7cf332162d994005abfb950 Mon Sep 17 00:00:00 2001
+From: Julien Castelain <julien.castelain@liferay.com>
+Date: Mon, 26 Apr 2021 09:44:44 +0200
+Subject: [PATCH] LPS-130835 Patch balloontoolbar and balloonpanel plugins
+
+This patch aims to improve the `balloontoolbar` and `balloonpanel` plugins
+behavior: with these changes the balloon toolbar will be placed on the
+current selection instead of being centered on top of it.
+---
+ plugins/balloonpanel/plugin.js   | 285 ++++++++-----------------------
+ plugins/balloontoolbar/plugin.js |  39 ++++-
+ 2 files changed, 109 insertions(+), 215 deletions(-)
+
+diff --git a/plugins/balloonpanel/plugin.js b/plugins/balloonpanel/plugin.js
+index 736e38295..540314bd6 100644
+--- a/plugins/balloonpanel/plugin.js
++++ b/plugins/balloonpanel/plugin.js
+@@ -11,6 +11,9 @@
+ ( function() {
+ 	'use strict';
+ 
++	CKEDITOR.SELECTION_TOP_TO_BOTTOM = 0;
++	CKEDITOR.SELECTION_BOTTOM_TO_TOP = 1;
++
+ 	// This flag prevents appending stylesheet more than once.
+ 	var stylesLoaded = false;
+ 
+@@ -49,6 +52,12 @@
+ 		this.editor = editor;
+ 
+ 		CKEDITOR.tools.extend( this, {
++
++			/**
++			 * The default padding for the balloonpanel.
++			 */
++			padding: 14,
++
+ 			/**
+ 			 * The default width of the balloon panel.
+ 			 */
+@@ -158,6 +167,30 @@
+ 	};
+ 
+ 	CKEDITOR.ui.balloonPanel.prototype = {
++		_getSelectionDirection: function() {
++			var direction = CKEDITOR.SELECTION_TOP_TO_BOTTOM;
++			var editor = this.editor;
++			var selection = editor.getSelection();
++			var nativeSelection = selection.getNative();
++
++			if (!nativeSelection) {
++				return CKEDITOR.SELECTION_TOP_TO_BOTTOM;
++			}
++
++			var anchorNode;
++
++			if ((anchorNode = nativeSelection.anchorNode) && anchorNode.compareDocumentPosition) {
++				var position = anchorNode.compareDocumentPosition(nativeSelection.focusNode);
++				if (
++					(!position &&
++						nativeSelection.anchorOffset > nativeSelection.focusOffset) ||
++					position === Node.DOCUMENT_POSITION_PRECEDING) {
++					direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
++				}
++			}
++			return direction;
++		},
++
+ 		/**
+ 		 * @property templateDefinitions Balloon panel templates. Automatically converted into a {@link CKEDITOR.template} in the panel constructor.
+ 		 * @property {String} templateDefinitions.panel The template for the panel outermost container.
+@@ -331,240 +364,64 @@
+ 		 * @param {Boolean} [options.show=true] Defines if the balloon panel should be shown after being attached.
+ 		 */
+ 		attach: ( function() {
+-			var winGlobal, frame, editable, isInline;
+-
+-			function rectIntersectArea( rect1, rect2 ) {
+-				var hOverlap = Math.max( 0, Math.min( rect1.right, rect2.right ) - Math.max( rect1.left, rect2.left ) ),
+-					vOverlap = Math.max( 0, Math.min( rect1.bottom, rect2.bottom ) - Math.max( rect1.top, rect2.top ) );
+-
+-				return hOverlap * vOverlap;
+-			}
+-
+-			function newPanelRect( top, left, panelWidth, panelHeight ) {
+-				var newRect = {
+-					top: top,
+-					left: left
+-				};
+-
+-				newRect.right = newRect.left + panelWidth;
+-				newRect.bottom = newRect.top + panelHeight;
+-
+-				return newRect;
+-			}
+-
+-			function createLineRect( first, last ) {
+-				var newRect = first;
+-				newRect.right = last.right;
+-				newRect.width = newRect.right - newRect.left;
+-
+-				if ( last.y ) {
+-					newRect.y = last.y;
++			return function(elementOrSelection, options) {
++				if (options instanceof CKEDITOR.dom.element || !options) {
++					options = {focusElement: options};
+ 				}
+ 
+-				return newRect;
+-			}
+-
+-			function getTopAndBottomRects( rectList ) {
+-				var topAlignedRects = getAlignedRects( rectList, true ),
+-					bottomAlignedRects = getAlignedRects( rectList ),
+-					first = createLineRect( topAlignedRects[ 0 ], topAlignedRects.pop() ),
+-					last = createLineRect( bottomAlignedRects[ 0 ], bottomAlignedRects.pop() );
+-
+-				// Make height of both rects equal to height of whole selection, so panel won't cover selection unless it needs to.
+-				first.bottom = last.bottom;
+-				first.height = first.bottom - first.top;
+-				if ( last.y ) {
+-					first.y = last.y;
+-				}
+-
+-				last.top = first.top;
+-				last.height = first.height;
+-
+-				return [ first, last ];
+-			}
+-
+-			function getAlignedRects( rectList, top ) {
+-				var edgeRect = top ? rectList [ 0 ] : rectList[ rectList.length - 1 ],
+-					alignment = top ? 'top' : 'bottom';
+-
+-				return CKEDITOR.tools.array.filter( rectList, function( item ) {
+-					if ( item[ alignment ] === edgeRect[ alignment ] ) {
+-						return item;
+-					}
+-				} );
+-			}
+-
+-			var triangleRelativePosition = {
+-				right: 'left',
+-				top: 'bottom',
+-				topLeft: 'bottomLeft',
+-				topRight: 'bottomRight',
+-				bottom: 'top',
+-				bottomLeft: 'topLeft',
+-				bottomRight: 'topRight',
+-				left: 'right'
+-			};
+-
+-			return function( elementOrSelection, options ) {
+-				if ( elementOrSelection instanceof CKEDITOR.dom.selection ) {
+-					var ranges = elementOrSelection.getRanges(),
+-						rectList;
+-
+-					// Handle fake selection within table.
+-					if ( elementOrSelection.isFake && elementOrSelection.isInTable() ) {
+-						rectList = CKEDITOR.tools.array.map( ranges, function( item ) {
+-							// With table selection the first rect represents `td` element rect. Lets use it in that case.
+-							return item.getClientRects( true )[ 0 ];
+-						} );
+-					} else {
+-						rectList = ranges[ ranges.length - 1 ].getClientRects( true );
+-					}
+-
+-					// We need two rects, one representing the first selected line, and other representing the last selected line.
+-					var first = rectList[ 0 ],
+-						last = rectList[ rectList.length - 1 ],
+-						selectionRects;
+-
+-					if ( first === last ) {
+-						selectionRects = [ first ];
+-					} else if ( first.top === last.top ) {
+-						selectionRects = [ createLineRect( first, last ) ];
+-					} else {
+-						selectionRects = getTopAndBottomRects( rectList );
+-					}
+-				}
+-
+-				if ( options instanceof CKEDITOR.dom.element || !options ) {
+-					options = { focusElement: options };
+-				}
+-
+-				options = CKEDITOR.tools.extend( options, {
++				options = CKEDITOR.tools.extend(options, {
+ 					show: true
+-				} );
++				});
+ 
+-				if ( options.show === true ) {
++				if (options.show === true) {
+ 					this.show();
+ 				}
+ 
+-				this.fire( 'attach' );
++				this.fire('attach');
+ 
+-				winGlobal = CKEDITOR.document.getWindow();
+-				frame = this.editor.window.getFrame();
+-				editable = this.editor.editable();
+-				isInline = editable.isInline();
++				var direction = this._getSelectionDirection();
+ 
+-				if ( !isInline && CKEDITOR.env.safari ) {
+-					// Overwrite frame with editor iframe closest parent, because iframe has wrong rect values in mobile Safari (#1076).
+-					frame = frame.getParent();
++				var editable = this.editor.editable();
++				var editableClientRect = editable.getClientRect(true);
++
++				var panelClientRect = this.parts.panel.getClientRect(true);
++
++				var ranges = elementOrSelection.getRanges();
++				var range = ranges[0];
++				var rangeClientRects = range.getClientRects(true);
++				var firstClientRect = rangeClientRects[0];
++				var lastClientRect = rangeClientRects[rangeClientRects.length - 1];
++
++				if (firstClientRect === lastClientRect) {
++					direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
+ 				}
+ 
+-				var panelWidth = this.getWidth(),
+-					panelHeight = this.getHeight(),
++				var rangeHeight = lastClientRect.bottom - firstClientRect.top;
+ 
+-					// The area of the panel.
+-					panelArea = panelWidth * panelHeight,
+-					alignments, minDifferenceAlignment, alignmentRect, areaDifference,
++				var clientRects = CKEDITOR.tools.array.map(ranges, function(range) {
++					return range.getClientRects(true)[0];
++				});
++				var clientRect = clientRects[0];
+ 
+-					elementRect = elementOrSelection.getClientRect && elementOrSelection.getClientRect( true ),
+-					editorRect = isInline ? editable.getClientRect( true ) : frame.getClientRect( true ),
++				var x = clientRect.x  + (clientRect.width / 2) - (panelClientRect.width / 2);
++				var y = clientRect.y - panelClientRect.height - this.padding;
+ 
+-					viewPaneSize = winGlobal.getViewPaneSize(),
+-					winGlobalScroll = winGlobal.getScrollPosition(),
+-
+-				// allowedRect is the rect into which the panel should fit to remain
+-				// both within the visible area of the editor and the viewport, i.e.
+-				// the rect area covered by "#":
+-				//
+-				// 	[Viewport]
+-				// 	+-------------------------------------+
+-				// 	|                        [Editor]     |
+-				// 	|                        +--------------------+
+-				// 	|                        |############|       |
+-				// 	|                        |############|       |
+-				// 	|                        |############|       |
+-				// 	|                        +--------------------+
+-				// 	|                                     |
+-				// 	+-------------------------------------+
+-					allowedRect = {
+-						top: Math.max( editorRect.top, winGlobalScroll.y ),
+-						left: Math.max( editorRect.left, winGlobalScroll.x ),
+-						right: Math.min( editorRect.right, viewPaneSize.width + winGlobalScroll.x ),
+-						bottom: Math.min( editorRect.bottom, viewPaneSize.height + winGlobalScroll.y )
+-					},
+-					alignmentKeys;
+-
+-				// Position balloon on entire view port only when it's real inline mode (#1048).
+-				if ( isInline && this.editor.elementMode === CKEDITOR.ELEMENT_MODE_INLINE ) {
+-					// In inline we want to limit position within the window.
+-					allowedRect = this._getViewPaneRect( winGlobal );
+-
+-					// We need also consider triangle.
+-					allowedRect.right += this.triangleWidth;
+-					allowedRect.bottom += this.triangleHeight;
++				if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
++					y = clientRect.y + rangeHeight + (this.padding);
+ 				}
+ 
+-				// This method will modify elementRect if the element is outside of allowedRect / editorRect.
+-				// If it's outside then in
+-				if ( selectionRects ) {
+-					CKEDITOR.tools.array.forEach( selectionRects, function( item ) {
+-						this._adjustElementRect( item, isInline ? allowedRect : editorRect );
+-					}, this );
+-
+-					alignments = this._getAlignments( selectionRects[ 0 ], panelWidth, panelHeight );
+-
+-					if ( selectionRects.length > 1 ) {
+-						alignments[ 'bottom hcenter' ] = this._getAlignments( selectionRects[ 1 ], panelWidth, panelHeight )[ 'bottom hcenter' ];
+-					}
+-
+-					alignmentKeys = {
+-						'top hcenter': true,
+-						'bottom hcenter': true
+-					};
+-				} else {
+-					this._adjustElementRect( elementRect, isInline ? allowedRect : editorRect );
+-					alignments = this._getAlignments( elementRect, panelWidth, panelHeight );
++				if (x < editableClientRect.x) {
++					x = editableClientRect.x * 2;
++				}
++				if (x + panelClientRect.width > editableClientRect.width) {
++					x  -= (x + panelClientRect.width) - editableClientRect.width;
+ 				}
+ 
+-				// Iterate over all possible alignments to find the optimal one.
+-				for ( var a in alignmentKeys || alignments ) {
+-					// Create a rect which would represent the panel in such alignment.
+-					alignmentRect = newPanelRect( alignments[ a ].top, alignments[ a ].left, panelWidth, panelHeight );
+-
+-					// Calculate the difference between the area of the panel and intersection of allowed rect and alignment rect.
+-					// It is the area of the panel, which would be OUT of allowed rect if such alignment was used. Less is better.
+-					areaDifference = alignments[ a ].areaDifference = panelArea - rectIntersectArea( alignmentRect, allowedRect );
+-
+-					// If the difference is 0, it means that the panel is fully within allowed rect. That's great!
+-					if ( areaDifference === 0 ) {
+-						minDifferenceAlignment = a;
+-						break;
+-					}
+-
+-					// If there's no alignment of a minimal area difference, use the first available.
+-					if ( !minDifferenceAlignment ) {
+-						minDifferenceAlignment = a;
+-					}
+-
+-					// Determine the alignment of a minimal area difference. It will be used as a fallback
+-					// if no alignment provides a perfect fit into allowed rect.
+-					if ( areaDifference < alignments[ minDifferenceAlignment ].areaDifference ) {
+-						minDifferenceAlignment = a;
+-					}
++				if (y < editableClientRect.y) {
++					y = clientRect.bottom + this.padding;
+ 				}
+ 
+-				// For non-static parent elements we need to remove its margin offset from balloon panel (#1048).
+-				var parent = this.parts.panel.getAscendant( function( el ) {
+-						return el instanceof CKEDITOR.dom.document ? false : el.getComputedStyle( 'position' ) !== 'static';
+-					} ),
+-					parentMargin = {
+-						left: parent ? parseInt( parent.getComputedStyle( 'margin-left' ), 10 ) : 0,
+-						top: parent ? parseInt( parent.getComputedStyle( 'margin-top' ), 10 ) : 0
+-					};
+-
+-				this.move( alignments[ minDifferenceAlignment ].top - parentMargin.top , alignments[ minDifferenceAlignment ].left - parentMargin.left );
+-
+-				minDifferenceAlignment = minDifferenceAlignment.split( ' ' );
+-				this.setTriangle( triangleRelativePosition[ minDifferenceAlignment[ 0 ] ], minDifferenceAlignment[ 1 ] );
++				this.move(y , x);
+ 
+ 				// Set focus to proper element.
+ 				if ( options.focusElement !== false ) {
+diff --git a/plugins/balloontoolbar/plugin.js b/plugins/balloontoolbar/plugin.js
+index 318fabe95..834b09f5a 100644
+--- a/plugins/balloontoolbar/plugin.js
++++ b/plugins/balloontoolbar/plugin.js
+@@ -527,7 +527,19 @@
+ 			this.hide();
+ 
+ 			if ( contextMatched ) {
+-				contextMatched.show( highlightElement );
++				CKEDITOR.tools.array.forEach(
++					selection.getRanges(),
++					function(range) {
++						range.shrink(CKEDITOR.SHRINK_ELEMENT, true);
++					}
++				);
++
++
++				if (!selection.getSelectedElement() && !selection.getSelectedText()) {
++					return
++				}
++
++				contextMatched.show(selection);
+ 			}
+ 		},
+ 
+@@ -655,6 +667,31 @@
+ 				return;
+ 			}
+ 			pluginInit = true;
++
++			var _editorDocumentListeners = [];
++
++			editor.on('contentDom', function(event) {
++				var document = editor.document;
++
++				_editorDocumentListeners.push(
++					document.on('keyup', function() {
++						editor.forceNextSelectionCheck();
++					})
++				);
++
++				_editorDocumentListeners.push(
++					document.on('mouseup', function() {
++						editor.forceNextSelectionCheck();
++					})
++				);
++			});
++
++			editor.on('destroy', function() {
++				CKEDITOR.tools.array.forEach(_editorDocumentListeners, function(listener) {
++					listener.removeListener();
++				});
++			});
++
+ 			CKEDITOR.ui.balloonToolbarView.prototype = CKEDITOR.tools.extend( {}, CKEDITOR.ui.balloonPanel.prototype );
+ 
+ 			/**


### PR DESCRIPTION
These changes contain the necessary patch to make ckeditor's
[balloontoolbar](https://ckeditor.com/cke4/addon/balloontoolbar) plugin behave (more or less) like Alloy Editor's
toolbars.

**Default behavior**
![](https://user-images.githubusercontent.com/5572/115395727-7d325c80-a1e4-11eb-9ba4-47c1b6729ff4.gif)

**Patched**
![](https://user-images.githubusercontent.com/5572/115395779-8f13ff80-a1e4-11eb-9b56-a670f1c53f3a.gif)
