### PR TITLE
chore: update @clayui/css dependency to v3.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"@babel/generator": "^7.12.5",
 		"@babel/parser": "^7.12.7",
 		"@babel/traverse": "^7.12.9",
-		"@clayui/css": "^3.14.0",
+		"@clayui/css": "^3.27.0",
 		"codemirror": "^5.57.0",
 		"prettier": "2.0.4"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,10 +93,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@clayui/css@^3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.14.0.tgz#5b9093322b2ca8bfe6c6edea960c8dcc89f5ddc3"
-  integrity sha512-uvtMif/1uifDWXuN0o0+sxSZD57kGp0ZIV4/0QLejAwfaXOp1kcSZiIjPAxNMclLzxCmPRIU+Hy5PU006MglQg==
+"@clayui/css@^3.27.0":
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.27.0.tgz#3bab0f8b121f4e0c36bb0a997b0c0ea114fd5f79"
+  integrity sha512-wroVtWOU2MKK5JWhMLJt08Kfm0C/xtNm5RKdLsCHOQ2XuTTDscBL7yQ9xRlR+bU1LOBOVe3RvbiDOn7FfGcbKw==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
In order to make sure have the latest icons available in `@clayui/css`
because we're going to need them for [LPS-132048](https://issues.liferay.com/browse/LPS-132048)

And because of this we'll also need to cut a release :tada: 