### PR TITLE
fix: remove unneeded styles

### DIFF
--- a/plugins/balloontoolbar/skins/moono-lexicon/balloontoolbar.css
+++ b/plugins/balloontoolbar/skins/moono-lexicon/balloontoolbar.css
@@ -46,13 +46,3 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 .cke_balloon.cke_balloontoolbar .cke_combo a.cke_combo_button {
 	margin: 0 1px 0 -2px;
 }
-
-/* Combo states (#1682). */
-.cke_balloon.cke_balloontoolbar .cke_combo_on a.cke_combo_button,
-.cke_balloon.cke_balloontoolbar .cke_combo_off a.cke_combo_button:hover,
-.cke_balloon.cke_balloontoolbar .cke_combo_off a.cke_combo_button:focus,
-.cke_balloon.cke_balloontoolbar .cke_combo_off a.cke_combo_button:active {
-	border: none;
-	padding: 1px;
-	outline: 1px solid #bcbcbc;
-}


### PR DESCRIPTION
This fixes the visual glitch produced when selecting an element
in the CKEDITOR.ui.richCombo element used by the [Styles
Combo](https://ckeditor.com/cke4/addon/stylescombo) plugin

**Before**
![](https://user-images.githubusercontent.com/5572/118956167-a5d28100-b95f-11eb-8514-81cfe0806bd4.gif)

**After**
![](https://user-images.githubusercontent.com/5572/118956183-aa973500-b95f-11eb-813b-0cfe1fb76f89.gif)

**Warning**
Depends on #175 

[EDIT] If you think it's a better idea to fold these changes into #175, I can do it too.
