### PR TITLE
chore: update ckeditor-dev to 4.16.1

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From 0daceabbc2fa55b8dc49c8e33355d9f15a9ac82e Mon Sep 17 00:00:00 2001
+From 42a85ce0aa92728368de2f3231d162b5f516b546 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11
@@ -10,7 +10,7 @@ Changed position of drag icon for IE.
  1 file changed, 4 insertions(+)
 
 diff --git a/plugins/widget/plugin.js b/plugins/widget/plugin.js
-index 8364a56e4..8cbc67e60 100644
+index 85b6103b1..47ebe4b01 100644
 --- a/plugins/widget/plugin.js
 +++ b/plugins/widget/plugin.js
 @@ -1607,6 +1607,10 @@

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From e0e24be6d941b9696bf9b0fd25372b2a02014ac4 Mon Sep 17 00:00:00 2001
+From 2d2178f9a8a147d08eb1c343cf9f4f7f4fd0d1a4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From 0bf369f37c92ff1dda81f917fd564917de656f24 Mon Sep 17 00:00:00 2001
+From e60f8b0aa89bb807bddf2bfd6650204477c2521b Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers
@@ -18,10 +18,10 @@ https://github.com/liferay/liferay-ckeditor/commit/328017c65063ac18119e244fec92d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/selection.js b/core/selection.js
-index 61247b33f..bd05660fb 100644
+index 72a02ef9f..4da7aff70 100644
 --- a/core/selection.js
 +++ b/core/selection.js
-@@ -2250,7 +2250,7 @@
+@@ -2278,7 +2278,7 @@
  
  					var nativeRange = this.document.$.createRange();
  

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From 7fc645c749ecc0554f5bc6f082254cbb93ed31db Mon Sep 17 00:00:00 2001
+From 01b1b407277a73413afa9ceaa384e04504bfabca Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 06c4a36dc3954c56745b4345e74ad2c3d907dfe5 Mon Sep 17 00:00:00 2001
+From cf5f37d25b11ff698864e3f279dee60c60df09db Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters
@@ -47,7 +47,7 @@ index dcd1b6bfa..8285e83c6 100644
  
  			/**
 diff --git a/core/config.js b/core/config.js
-index 3955317eb..33e882926 100644
+index 1ebc05355..4d7013209 100644
 --- a/core/config.js
 +++ b/core/config.js
 @@ -8,6 +8,15 @@

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From b0078d6cf0e463287e2d42026db7cd7828690c42 Mon Sep 17 00:00:00 2001
+From 88c6f195371052e2f9491d35b15affde3cd67963 Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From a72b2910faf30e1e9bfd57a0a3ef5088fc3f0398 Mon Sep 17 00:00:00 2001
+From 8fecbda83ae3c616af9eeb61ebaa377ee814fd67 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From e768775e1c378c14d836d1f8e9ae3fcd7c750a94 Mon Sep 17 00:00:00 2001
+From b60cd4d2f5bfdb63e6655615395e7d9ad204d514 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,

--- a/patches/0009-LPS-131699-Add-null-check.patch
+++ b/patches/0009-LPS-131699-Add-null-check.patch
@@ -1,4 +1,4 @@
-From 7c5d61c5cec06be8f8ad504fe45ab7890de73950 Mon Sep 17 00:00:00 2001
+From 5c4857e1f72976575bbb8515ebf423ba27fdd7a7 Mon Sep 17 00:00:00 2001
 From: IstvanD <istvan.dezsi@liferay.com>
 Date: Wed, 19 May 2021 17:43:17 +0200
 Subject: [PATCH] LPS-131699 Add null check
@@ -8,17 +8,17 @@ Subject: [PATCH] LPS-131699 Add null check
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/core/event.js b/core/event.js
-index 449840c2a..91c2d50ae 100644
+index 049090253..3ff2cde4b 100644
 --- a/core/event.js
 +++ b/core/event.js
-@@ -164,7 +164,9 @@ if ( !CKEDITOR.event ) {
- 				}
+@@ -172,7 +172,9 @@
+ 					}
  
- 				function removeListener() {
--					me.removeListener( eventName, listenerFunction );
-+					if (me) {
-+						me.removeListener( eventName, listenerFunction );
-+					}
- 				}
+ 					function removeListener() {
+-						me.removeListener( eventName, listenerFunction );
++						if (me) {
++							me.removeListener( eventName, listenerFunction );
++						}
+ 					}
  
- 				var event = getEntry.call( this, eventName );
+ 					var event = getEntry.call( this, eventName );


### PR DESCRIPTION
Hey @liferay,

Attached is an update for to upgrade CKEditor to [4.16.1](https://github.com/ckeditor/ckeditor4/tree/4.16.1).

Please let me know if you have any questions. Thanks!