### PR TITLE
fix: enable browser native menu in codemirror plugin

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -35,6 +35,9 @@
 
 				instance.codeMirrorEditor.setValue(oldData);
 
+				var codeMirrorElement = instance.codeMirrorEditor.getWrapperElement();
+				codeMirrorElement.classList.add('cke_enable_context_menu');
+
 				var editableParent = editable.getParent();
 				var contentsSize = editableParent.getClientSize();
 				if (contentsSize.height) {


### PR DESCRIPTION
When we switched to  the `codemirror` plugin, right clicking in source mode no longer worked. 
By adding the `cke_enable_context_menu` CSS class to the `codemirror` plugin, 
the browser's native context menu is enabled.

See [LPS-134687](https://issues.liferay.com/browse/LPS-134687)
Fixes #180

Let me know if there are any questions or comments about this.
Thank you.