### PR TITLE
fix: retrieve hspace and vspace values from style

### DIFF
--- a/plugins/imagespacingbox/plugin.js
+++ b/plugins/imagespacingbox/plugin.js
@@ -19,6 +19,36 @@
 							{
 								children: [
 									{
+										onShow: function () {
+											var parentEditor = this.getDialog().getParentEditor();
+											var widget =
+												parentEditor.widgets.focused;
+
+											if (widget) {
+												var imageElement =
+													widget.parts.image.$;
+												var style = imageElement.style;
+
+												var hspace = '';
+
+												if (style) {
+													hspace =
+														parseInt(
+															style.marginLeft,
+															10
+														) ||
+														parseInt(
+															style.marginRight,
+															10
+														);
+												}
+
+												widget.setData(
+													'hspace',
+													hspace
+												);
+											}
+										},
 										commit: function (widget) {
 											widget.setData(
 												'hspace',
@@ -57,6 +87,36 @@
 							{
 								children: [
 									{
+										onShow: function () {
+											var parentEditor = this.getDialog().getParentEditor();
+											var widget =
+												parentEditor.widgets.focused;
+
+											if (widget) {
+												var imageElement =
+													widget.parts.image.$;
+												var style = imageElement.style;
+
+												var vspace = '';
+
+												if (style) {
+													vspace =
+														parseInt(
+															style.marginTop,
+															10
+														) ||
+														parseInt(
+															style.marginBottom,
+															10
+														);
+												}
+
+												widget.setData(
+													'vspace',
+													vspace
+												);
+											}
+										},
 										commit: function (widget) {
 											widget.setData(
 												'vspace',

--- a/plugins/imagespacingbox/plugin.js
+++ b/plugins/imagespacingbox/plugin.js
@@ -55,12 +55,14 @@
 												this.getValue()
 											);
 
-											var hspace = widget.data.hspace;
+											var hspace = widget.data.hspace
+												? widget.data.hspace
+												: 0;
 
 											var imageElement =
 												widget.parts.image;
 
-											if (imageElement && hspace) {
+											if (imageElement) {
 												imageElement.setStyles({
 													'margin-left':
 														hspace + 'px',
@@ -123,12 +125,14 @@
 												this.getValue()
 											);
 
-											var vspace = widget.data.vspace;
+											var vspace = widget.data.vspace
+												? widget.data.vspace
+												: 0;
 
 											var imageElement =
 												widget.parts.image;
 
-											if (imageElement && vspace) {
+											if (imageElement) {
 												imageElement.setStyles({
 													'margin-bottom':
 														vspace + 'px',


### PR DESCRIPTION
Please see [LPS-134777](https://issues.liferay.com/browse/LPS-134777) for more information.

We could have multiple cases scenarios, take in mind that a user can change the source code as he likes, so we need to check on each dialogue display the styles of the selected image.
These are all the possible cases I found, if the user did:
1. not apply any style or hspace or vspace in the dialog, this will mean empty values

2. apply only hspace, the style would be: style="margin-left: 10px; margin-right: 10px;"

3. apply only one vspace, the style would be: style="margin-bottom: 10px; margin-top: 10px;"

4. apply hspace and vspace, the style would be: style="margin: 20px 10px;"

5. applied the same value for hspace and vspace, the style would be: style="margin: 10px;"

6. change this style from source code as he wants, so we need to interpret this values as possible as we can, that why I put all the conditions above.

/cc @orsolyaDekany 

Fixes #182