### PR TITLE
fix: Maximize plugin breaks the UI in Firefox

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From 69dba89b93f8f3873f24a182729f5db5edba0436 Mon Sep 17 00:00:00 2001
+From befb29f639df8edaa059c24bc540c7453eb68159 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11
@@ -10,7 +10,7 @@ Changed position of drag icon for IE.
  1 file changed, 4 insertions(+)
 
 diff --git a/plugins/widget/plugin.js b/plugins/widget/plugin.js
-index 85b6103b17..47ebe4b012 100644
+index 85b6103b1..47ebe4b01 100644
 --- a/plugins/widget/plugin.js
 +++ b/plugins/widget/plugin.js
 @@ -1607,6 +1607,10 @@

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 9736aabd532e839c72f14e8038682081e4f2c05c Mon Sep 17 00:00:00 2001
+From 776bd4cd69d11597b5960909930473765ee923e5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized
@@ -11,7 +11,7 @@ plugin.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/plugins/dialog/plugin.js b/plugins/dialog/plugin.js
-index 9a8d6fb200..8a94776f5f 100644
+index 9a8d6fb20..8a94776f5 100644
 --- a/plugins/dialog/plugin.js
 +++ b/plugins/dialog/plugin.js
 @@ -1184,7 +1184,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From 9cf72900b67718dcd1d258d2fcc325f68c8efd69 Mon Sep 17 00:00:00 2001
+From fd35435fde6432c20422d3fef515821912d62da0 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers
@@ -18,7 +18,7 @@ https://github.com/liferay/liferay-ckeditor/commit/328017c65063ac18119e244fec92d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/selection.js b/core/selection.js
-index 72a02ef9f0..4da7aff707 100644
+index 72a02ef9f..4da7aff70 100644
 --- a/core/selection.js
 +++ b/core/selection.js
 @@ -2278,7 +2278,7 @@

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From 244bc15213507d0d3ef1894c8ba0e537ddbebd66 Mon Sep 17 00:00:00 2001
+From dab0625472b6ae273680432ea0dab3d5b90ec0a4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements
@@ -15,7 +15,7 @@ Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements
  8 files changed, 38 insertions(+), 56 deletions(-)
 
 diff --git a/plugins/table/dialogs/table.js b/plugins/table/dialogs/table.js
-index 5c42bc5c07..b19c2515df 100755
+index 5c42bc5c0..b19c2515d 100755
 --- a/plugins/table/dialogs/table.js
 +++ b/plugins/table/dialogs/table.js
 @@ -523,22 +523,6 @@
@@ -42,7 +42,7 @@ index 5c42bc5c07..b19c2515df 100755
  				} ]
  			},
 diff --git a/plugins/table/plugin.js b/plugins/table/plugin.js
-index ec3b769ba4..43ef13d931 100755
+index ec3b769ba..43ef13d93 100755
 --- a/plugins/table/plugin.js
 +++ b/plugins/table/plugin.js
 @@ -18,7 +18,7 @@ CKEDITOR.plugins.add( 'table', {
@@ -55,7 +55,7 @@ index ec3b769ba4..43ef13d931 100755
  				'th td tr[scope];' +
  				'td{border*,background-color,vertical-align,width,height}[colspan,rowspan];' +
 diff --git a/tests/plugins/table/table.html b/tests/plugins/table/table.html
-index e6766708df..6b97e0c699 100644
+index e6766708d..6b97e0c69 100644
 --- a/tests/plugins/table/table.html
 +++ b/tests/plugins/table/table.html
 @@ -37,7 +37,7 @@
@@ -68,7 +68,7 @@ index e6766708df..6b97e0c699 100644
  	<thead>
  	<tr>
 diff --git a/tests/plugins/table/table.js b/tests/plugins/table/table.js
-index 6e1cc30614..104de739c2 100644
+index 6e1cc3061..104de739c 100644
 --- a/tests/plugins/table/table.js
 +++ b/tests/plugins/table/table.js
 @@ -80,16 +80,14 @@
@@ -91,7 +91,7 @@ index 6e1cc30614..104de739c2 100644
  					dialog.fire( 'ok' );
  					dialog.hide();
 diff --git a/tests/plugins/tableselection/integrations/tabletools/tabletools.html b/tests/plugins/tableselection/integrations/tabletools/tabletools.html
-index a9df442abb..eccbbafa70 100644
+index a9df442ab..eccbbafa7 100644
 --- a/tests/plugins/tableselection/integrations/tabletools/tabletools.html
 +++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.html
 @@ -1,5 +1,5 @@
@@ -237,7 +237,7 @@ index a9df442abb..eccbbafa70 100644
  	<tr>
  		<td>cell1</td>
 diff --git a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
-index da23513f94..7abd4bcdfb 100644
+index da23513f9..7abd4bcdf 100644
 --- a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
 +++ b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
 @@ -1,5 +1,5 @@
@@ -248,7 +248,7 @@ index da23513f94..7abd4bcdfb 100644
  		<tr>
  			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
 diff --git a/tests/plugins/tabletools/manual/columndeletionerror.html b/tests/plugins/tabletools/manual/columndeletionerror.html
-index b3cc3d03b5..f84850c69a 100644
+index b3cc3d03b..f84850c69 100644
 --- a/tests/plugins/tabletools/manual/columndeletionerror.html
 +++ b/tests/plugins/tabletools/manual/columndeletionerror.html
 @@ -1,5 +1,5 @@
@@ -259,7 +259,7 @@ index b3cc3d03b5..f84850c69a 100644
  		<tr>
  			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
 diff --git a/tests/plugins/tabletools/tabletools.html b/tests/plugins/tabletools/tabletools.html
-index 15d0ef1241..42ef17a6ef 100644
+index 15d0ef124..42ef17a6e 100644
 --- a/tests/plugins/tabletools/tabletools.html
 +++ b/tests/plugins/tabletools/tabletools.html
 @@ -1,5 +1,5 @@

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From d5c843a3651cfb17b8cf64802d69828046ab1597 Mon Sep 17 00:00:00 2001
+From 9252acb8e8bb56d642d0bd6be5fef96f6a140858 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-112982 Add additional resource URL parameters
  2 files changed, 27 insertions(+), 7 deletions(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index dcd1b6bfa3..8285e83c64 100644
+index dcd1b6bfa..8285e83c6 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -170,15 +170,26 @@ if ( !window.CKEDITOR ) {
@@ -47,7 +47,7 @@ index dcd1b6bfa3..8285e83c64 100644
  
  			/**
 diff --git a/core/config.js b/core/config.js
-index 1ebc053555..4d7013209a 100644
+index 1ebc05355..4d7013209 100644
 --- a/core/config.js
 +++ b/core/config.js
 @@ -8,6 +8,15 @@

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From cf69d7f5abe660d589eee39535959092d200e671 Mon Sep 17 00:00:00 2001
+From ad7a19a6e186700def0fc880685e90e4392f0692 Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index 8285e83c64..ea4d38f8f2 100644
+index 8285e83c6..ea4d38f8f 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -183,7 +183,7 @@ if ( !window.CKEDITOR ) {

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From 8f62a50afa6292d8fc3b4d22048cf7100359012c Mon Sep 17 00:00:00 2001
+From 44f40dde122ebfbd43f8f153dc8504a3d4e132cd Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11
@@ -11,7 +11,7 @@ they aren't loaded when getUrl is executed.
  1 file changed, 18 insertions(+), 12 deletions(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index ea4d38f8f2..fd94a94166 100644
+index ea4d38f8f..fd94a9416 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -170,26 +170,32 @@ if ( !window.CKEDITOR ) {

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From efbdfa7b616f984ba904dd4bcc8e1f055eb5cb9c Mon Sep 17 00:00:00 2001
+From db5919ebcf1e14657e676737ccbdee60a484d49a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/plugins/table/dialogs/table.js b/plugins/table/dialogs/table.js
-index b19c2515df..6ffa71dc0f 100755
+index b19c2515d..6ffa71dc0 100755
 --- a/plugins/table/dialogs/table.js
 +++ b/plugins/table/dialogs/table.js
 @@ -342,7 +342,7 @@

--- a/patches/0009-LPS-131699-Add-null-check.patch
+++ b/patches/0009-LPS-131699-Add-null-check.patch
@@ -1,4 +1,4 @@
-From a723ceb26452de4341377d6a0420ed1fdc48dbdf Mon Sep 17 00:00:00 2001
+From 4a9aad4f30729659137f24ad0223c1743188424c Mon Sep 17 00:00:00 2001
 From: IstvanD <istvan.dezsi@liferay.com>
 Date: Wed, 19 May 2021 17:43:17 +0200
 Subject: [PATCH] LPS-131699 Add null check
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-131699 Add null check
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/core/event.js b/core/event.js
-index 0490902530..3ff2cde4b6 100644
+index 049090253..3ff2cde4b 100644
 --- a/core/event.js
 +++ b/core/event.js
 @@ -172,7 +172,9 @@

--- a/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
+++ b/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
@@ -1,4 +1,4 @@
-From a2ebadce31c58f4a725f95905ef97b6a4146d37f Mon Sep 17 00:00:00 2001
+From 1425a04aa2d10a87530fef6326e8f2c6f0eaf81f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 9 Aug 2021 18:04:44 +0200
 Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/plugins/button/plugin.js b/plugins/button/plugin.js
-index 9cc0584169..e0c996e9e4 100644
+index 9cc058416..e0c996e9e 100644
 --- a/plugins/button/plugin.js
 +++ b/plugins/button/plugin.js
 @@ -143,7 +143,6 @@

--- a/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
+++ b/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
@@ -1,0 +1,33 @@
+From 5f16c174de2f4f4f79735314f15e39177a9d0c2d Mon Sep 17 00:00:00 2001
+From: Norbert Nemeth <norbert.nemeth@liferay.com>
+Date: Tue, 17 Aug 2021 11:20:58 +0200
+Subject: [PATCH] LPS-136998 Avoid breaking the UI in firefox
+
+---
+ plugins/maximize/plugin.js | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/plugins/maximize/plugin.js b/plugins/maximize/plugin.js
+index 2bb511945..7223c436e 100644
+--- a/plugins/maximize/plugin.js
++++ b/plugins/maximize/plugin.js
+@@ -72,19 +72,6 @@
+ 		if ( editor.editable().isInline() )
+ 			return;
+ 
+-		// Refresh all editor instances on the page (https://dev.ckeditor.com/ticket/5724).
+-		var all = CKEDITOR.instances;
+-		for ( var i in all ) {
+-			var one = all[ i ];
+-			if ( one.mode == 'wysiwyg' && !one.readOnly ) {
+-				var body = one.document.getBody();
+-				// Refresh 'contentEditable' otherwise
+-				// DOM lifting breaks design mode. (https://dev.ckeditor.com/ticket/5560)
+-				body.setAttribute( 'contentEditable', false );
+-				body.setAttribute( 'contentEditable', true );
+-			}
+-		}
+-
+ 		if ( editor.editable().hasFocus ) {
+ 			editor.toolbox.focus();
+ 			editor.focus();


### PR DESCRIPTION
This issue is we are putting contentEditable attribute to the body html, however it breaks the UI on Firefox. This change was introduce in https://dev.ckeditor.com/ticket/5560, reverting it does not reintroduce the issue.

Please review my changes,
Thanks! 

Fixes #186