### PR TITLE
fix: LPS-137425 Focusing on balloon editor toolbar may open an additional text toolbar

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From befb29f639df8edaa059c24bc540c7453eb68159 Mon Sep 17 00:00:00 2001
+From 3f85bfae11dd9c95ecdd4b43e4d99491fbbadd67 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11
@@ -10,7 +10,7 @@ Changed position of drag icon for IE.
  1 file changed, 4 insertions(+)
 
 diff --git a/plugins/widget/plugin.js b/plugins/widget/plugin.js
-index 85b6103b1..47ebe4b01 100644
+index 85b6103b17..47ebe4b012 100644
 --- a/plugins/widget/plugin.js
 +++ b/plugins/widget/plugin.js
 @@ -1607,6 +1607,10 @@

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 776bd4cd69d11597b5960909930473765ee923e5 Mon Sep 17 00:00:00 2001
+From 33fc73c335f3b31a83f64eeee9f715ec90be7401 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized
@@ -11,7 +11,7 @@ plugin.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/plugins/dialog/plugin.js b/plugins/dialog/plugin.js
-index 9a8d6fb20..8a94776f5 100644
+index 9a8d6fb200..8a94776f5f 100644
 --- a/plugins/dialog/plugin.js
 +++ b/plugins/dialog/plugin.js
 @@ -1184,7 +1184,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From fd35435fde6432c20422d3fef515821912d62da0 Mon Sep 17 00:00:00 2001
+From b64f7345dcfbcf99213298cab84b4684d2495b6b Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers
@@ -18,7 +18,7 @@ https://github.com/liferay/liferay-ckeditor/commit/328017c65063ac18119e244fec92d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/selection.js b/core/selection.js
-index 72a02ef9f..4da7aff70 100644
+index 72a02ef9f0..4da7aff707 100644
 --- a/core/selection.js
 +++ b/core/selection.js
 @@ -2278,7 +2278,7 @@

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From dab0625472b6ae273680432ea0dab3d5b90ec0a4 Mon Sep 17 00:00:00 2001
+From 8dc204972fdbc51b3757b74628404f6d3bde9fe4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements
@@ -15,7 +15,7 @@ Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements
  8 files changed, 38 insertions(+), 56 deletions(-)
 
 diff --git a/plugins/table/dialogs/table.js b/plugins/table/dialogs/table.js
-index 5c42bc5c0..b19c2515d 100755
+index 5c42bc5c07..b19c2515df 100755
 --- a/plugins/table/dialogs/table.js
 +++ b/plugins/table/dialogs/table.js
 @@ -523,22 +523,6 @@
@@ -42,7 +42,7 @@ index 5c42bc5c0..b19c2515d 100755
  				} ]
  			},
 diff --git a/plugins/table/plugin.js b/plugins/table/plugin.js
-index ec3b769ba..43ef13d93 100755
+index ec3b769ba4..43ef13d931 100755
 --- a/plugins/table/plugin.js
 +++ b/plugins/table/plugin.js
 @@ -18,7 +18,7 @@ CKEDITOR.plugins.add( 'table', {
@@ -55,7 +55,7 @@ index ec3b769ba..43ef13d93 100755
  				'th td tr[scope];' +
  				'td{border*,background-color,vertical-align,width,height}[colspan,rowspan];' +
 diff --git a/tests/plugins/table/table.html b/tests/plugins/table/table.html
-index e6766708d..6b97e0c69 100644
+index e6766708df..6b97e0c699 100644
 --- a/tests/plugins/table/table.html
 +++ b/tests/plugins/table/table.html
 @@ -37,7 +37,7 @@
@@ -68,7 +68,7 @@ index e6766708d..6b97e0c69 100644
  	<thead>
  	<tr>
 diff --git a/tests/plugins/table/table.js b/tests/plugins/table/table.js
-index 6e1cc3061..104de739c 100644
+index 6e1cc30614..104de739c2 100644
 --- a/tests/plugins/table/table.js
 +++ b/tests/plugins/table/table.js
 @@ -80,16 +80,14 @@
@@ -91,7 +91,7 @@ index 6e1cc3061..104de739c 100644
  					dialog.fire( 'ok' );
  					dialog.hide();
 diff --git a/tests/plugins/tableselection/integrations/tabletools/tabletools.html b/tests/plugins/tableselection/integrations/tabletools/tabletools.html
-index a9df442ab..eccbbafa7 100644
+index a9df442abb..eccbbafa70 100644
 --- a/tests/plugins/tableselection/integrations/tabletools/tabletools.html
 +++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.html
 @@ -1,5 +1,5 @@
@@ -237,7 +237,7 @@ index a9df442ab..eccbbafa7 100644
  	<tr>
  		<td>cell1</td>
 diff --git a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
-index da23513f9..7abd4bcdf 100644
+index da23513f94..7abd4bcdfb 100644
 --- a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
 +++ b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
 @@ -1,5 +1,5 @@
@@ -248,7 +248,7 @@ index da23513f9..7abd4bcdf 100644
  		<tr>
  			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
 diff --git a/tests/plugins/tabletools/manual/columndeletionerror.html b/tests/plugins/tabletools/manual/columndeletionerror.html
-index b3cc3d03b..f84850c69 100644
+index b3cc3d03b5..f84850c69a 100644
 --- a/tests/plugins/tabletools/manual/columndeletionerror.html
 +++ b/tests/plugins/tabletools/manual/columndeletionerror.html
 @@ -1,5 +1,5 @@
@@ -259,7 +259,7 @@ index b3cc3d03b..f84850c69 100644
  		<tr>
  			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
 diff --git a/tests/plugins/tabletools/tabletools.html b/tests/plugins/tabletools/tabletools.html
-index 15d0ef124..42ef17a6e 100644
+index 15d0ef1241..42ef17a6ef 100644
 --- a/tests/plugins/tabletools/tabletools.html
 +++ b/tests/plugins/tabletools/tabletools.html
 @@ -1,5 +1,5 @@

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 9252acb8e8bb56d642d0bd6be5fef96f6a140858 Mon Sep 17 00:00:00 2001
+From 032373bbc13e412f11d823ca9c156ad03af5b86d Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-112982 Add additional resource URL parameters
  2 files changed, 27 insertions(+), 7 deletions(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index dcd1b6bfa..8285e83c6 100644
+index dcd1b6bfa3..8285e83c64 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -170,15 +170,26 @@ if ( !window.CKEDITOR ) {
@@ -47,7 +47,7 @@ index dcd1b6bfa..8285e83c6 100644
  
  			/**
 diff --git a/core/config.js b/core/config.js
-index 1ebc05355..4d7013209 100644
+index 1ebc053555..4d7013209a 100644
 --- a/core/config.js
 +++ b/core/config.js
 @@ -8,6 +8,15 @@

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From ad7a19a6e186700def0fc880685e90e4392f0692 Mon Sep 17 00:00:00 2001
+From 652c578996d8f63bedc440240d6ffb38743d4736 Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index 8285e83c6..ea4d38f8f 100644
+index 8285e83c64..ea4d38f8f2 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -183,7 +183,7 @@ if ( !window.CKEDITOR ) {

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From 44f40dde122ebfbd43f8f153dc8504a3d4e132cd Mon Sep 17 00:00:00 2001
+From 23da2c52a6021b612aab12ba5fc20e9ec4af98bf Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11
@@ -11,7 +11,7 @@ they aren't loaded when getUrl is executed.
  1 file changed, 18 insertions(+), 12 deletions(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index ea4d38f8f..fd94a9416 100644
+index ea4d38f8f2..fd94a94166 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -170,26 +170,32 @@ if ( !window.CKEDITOR ) {

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From db5919ebcf1e14657e676737ccbdee60a484d49a Mon Sep 17 00:00:00 2001
+From 3618e615524aa75774dd10f5b7da68be822b2af7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/plugins/table/dialogs/table.js b/plugins/table/dialogs/table.js
-index b19c2515d..6ffa71dc0 100755
+index b19c2515df..6ffa71dc0f 100755
 --- a/plugins/table/dialogs/table.js
 +++ b/plugins/table/dialogs/table.js
 @@ -342,7 +342,7 @@

--- a/patches/0009-LPS-131699-Add-null-check.patch
+++ b/patches/0009-LPS-131699-Add-null-check.patch
@@ -1,4 +1,4 @@
-From 4a9aad4f30729659137f24ad0223c1743188424c Mon Sep 17 00:00:00 2001
+From 6def01b468469f0a17e1f8f6b746a9f19f50445e Mon Sep 17 00:00:00 2001
 From: IstvanD <istvan.dezsi@liferay.com>
 Date: Wed, 19 May 2021 17:43:17 +0200
 Subject: [PATCH] LPS-131699 Add null check
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-131699 Add null check
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/core/event.js b/core/event.js
-index 049090253..3ff2cde4b 100644
+index 0490902530..3ff2cde4b6 100644
 --- a/core/event.js
 +++ b/core/event.js
 @@ -172,7 +172,9 @@

--- a/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
+++ b/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
@@ -1,4 +1,4 @@
-From 1425a04aa2d10a87530fef6326e8f2c6f0eaf81f Mon Sep 17 00:00:00 2001
+From ac5b4d7d2e0978df1b37755c6f65b4da46f348b6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 9 Aug 2021 18:04:44 +0200
 Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/plugins/button/plugin.js b/plugins/button/plugin.js
-index 9cc058416..e0c996e9e 100644
+index 9cc0584169..e0c996e9e4 100644
 --- a/plugins/button/plugin.js
 +++ b/plugins/button/plugin.js
 @@ -143,7 +143,6 @@

--- a/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
+++ b/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
@@ -1,4 +1,4 @@
-From 5f16c174de2f4f4f79735314f15e39177a9d0c2d Mon Sep 17 00:00:00 2001
+From ca0a34d850c0dd61dd45ba40fba636efd761b23c Mon Sep 17 00:00:00 2001
 From: Norbert Nemeth <norbert.nemeth@liferay.com>
 Date: Tue, 17 Aug 2021 11:20:58 +0200
 Subject: [PATCH] LPS-136998 Avoid breaking the UI in firefox
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-136998 Avoid breaking the UI in firefox
  1 file changed, 13 deletions(-)
 
 diff --git a/plugins/maximize/plugin.js b/plugins/maximize/plugin.js
-index 2bb511945..7223c436e 100644
+index 2bb511945d..7223c436e1 100644
 --- a/plugins/maximize/plugin.js
 +++ b/plugins/maximize/plugin.js
 @@ -72,19 +72,6 @@

--- a/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
+++ b/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
@@ -1,0 +1,29 @@
+From e36124873d2d2e5c7f5235b5eb13d58f0ce1f1cf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
+Date: Mon, 16 Aug 2021 18:36:20 +0200
+Subject: [PATCH] LPS-137425 Don't check selection on focus
+
+---
+ core/selection.js | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/core/selection.js b/core/selection.js
+index 4da7aff707..e96202fb3c 100644
+--- a/core/selection.js
++++ b/core/selection.js
+@@ -976,15 +976,6 @@
+ 				editable.attachListener( editable, 'keydown', disableSelectionChangeForNonEditables, editor );
+ 			}
+ 
+-			// Always fire the selection change on focus gain.
+-			// On Webkit&Gecko (#1113) do this on focusin, because the selection is unlocked on it too and
+-			// we need synchronization between those listeners to not lost cached editor._.previousActive property
+-			// (which is updated on selectionCheck).
+-			editable.attachListener( editable, CKEDITOR.env.webkit || CKEDITOR.env.gecko ? 'focusin' : 'focus', function() {
+-				editor.forceNextSelectionCheck();
+-				editor.selectionChange( 1 );
+-			} );
+-
+ 			// https://dev.ckeditor.com/ticket/9699: On Webkit&Gecko in inline editor we have to check selection when it was changed
+ 			// by dragging and releasing mouse button outside editable. Dragging (mousedown)
+ 			// has to be initialized in editable, but for mouseup we listen on document element.


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-137425

In this PR, we are removing force selection update on `focus`. Selection update has a lot of side-effects, including opening a balloon toolbar. I tried multiple times to makes a workaround, see https://github.com/liferay-frontend/liferay-portal/pull/1284 and https://github.com/liferay-frontend/liferay-portal/pull/1350, but each solution leads to a new bug. I finally ran out of options, the only solution remaining to fix the root cause. 

I was hesitant to do modify base ckeditor because the comment references `previousActive` sync. Looking in more depth in the ckeditor code, I think removing this block is safe to do:
- I believe [this block](https://github.com/ckeditor/ckeditor4/blob/cae20318d46745cc46c811da4e7d68b38ca32449/core/selection.js#L800-L815) achieves the intended sync,  If this is true, we are just cleaning up old code. 
- I tested blur/focus selection behavior on FF and Chrome, before and after this PR, and I didn't see any difference. 
- The purpose of the removed code does not seem critical, restoring selection on blur/focus. The worst case scenario is we re-introduce a minor bug, affecting an edge case. A good trade-off for proper functioning of balloon editor. If that's the case, we will want to add a more precise solution, instead of forcing selection that has many side-effects.


Before PR:
![before](https://user-images.githubusercontent.com/5435511/129717332-1490a2d6-1cef-4b34-8aa0-cb995be7df3c.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/129717282-43038a3a-66f4-4d64-9d41-bc62f0577bb1.gif)