### PR TITLE
fix: [TS] LPS-139565

### DIFF
--- a/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
+++ b/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
@@ -1,0 +1,52 @@
+From 3edd637a32117992665065e07abbad4d556ca742 Mon Sep 17 00:00:00 2001
+From: Minhchau <minhchau.dang@liferay.com>
+Date: Tue, 28 Sep 2021 11:18:40 -0700
+Subject: [PATCH] LPS-139565 When upgrading from 6.2 to 7.1, image width/height
+ in web content is lost
+
+If inline styles for height/width are set on the image, prefer those over the natural height/width
+---
+ plugins/image2/plugin.js | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/plugins/image2/plugin.js b/plugins/image2/plugin.js
+index e85d58c2b..f40171644 100644
+--- a/plugins/image2/plugin.js
++++ b/plugins/image2/plugin.js
+@@ -375,8 +375,8 @@
+ 						hasCaption: !!this.parts.caption,
+ 						src: image.getAttribute( 'src' ),
+ 						alt: image.getAttribute( 'alt' ) || '',
+-						width: image.getAttribute( 'width' ) || '',
+-						height: image.getAttribute( 'height' ) || '',
++						width: image.$.style.width && parseInt( image.$.style.width ) || image.getAttribute( 'width' ) || '',
++						height: image.$.style.height && parseInt( image.$.style.height ) || image.getAttribute( 'height' ) || '',
+ 
+ 						// Lock ratio is on by default (https://dev.ckeditor.com/ticket/10833).
+ 						lock: this.ready ? helpers.checkHasNaturalRatio( image ) : true
+@@ -1117,6 +1117,8 @@
+ 				image.setAttribute( d, dimensions[ d ] );
+ 			else
+ 				image.removeAttribute( d );
++
++			image.$.style.removeProperty( d );
+ 		}
+ 	}
+ 
+@@ -1190,6 +1192,16 @@
+ 				nativeEvt, newWidth, newHeight, updateData,
+ 				moveDiffX, moveDiffY, moveRatio;
+ 
++			if (image.$.style.height) {
++				image.setAttribute( 'height', parseInt( image.$.style.height ) );
++				image.$.style.removeProperty( 'height' );
++			}
++
++			if (image.$.style.width) {
++				image.setAttribute( 'width', parseInt( image.$.style.width ) );
++				image.$.style.removeProperty( 'width' );
++			}
++
+ 			// Save the undo snapshot first: before resizing.
+ 			editor.fire( 'saveSnapshot' );
+ 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-139565

## Problem overview

In earlier versions of CKEditor, it set the height and width of a resized image as style properties. However, in later versions of CKEditor, it instead sets element attributes instead. As a result, any content created with the earlier version of CKEditor will run into issues in the newer versions of CKEditor.

## Steps to reproduce (in Liferay)

1. Navigate to the screen to create a new web content
2. Access the WYSIWYG editor and upload an image to the document library and add it to the content
3. Switch to the source view and add the `style="height:100px; width:100px"` attribute to the `img` tag to simulate content created in earlier versions of Liferay
4. Publish the web content
5. Edit the web content that you created
6. Attempt to resize the image using either the dragresizer or by double-clicking on the image to load Image Properties

Expected behavior is that reloading the content in WYSIWYG view will result in an image that can be resized. Actual behavior is that the inline styling makes it impossible to resize the image.