### PR TITLE
fix: makes cke_resizer_rtl float to the right due to liferay-r2

### DIFF
--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -174,7 +174,11 @@ Special outer level classes used in this file:
 
 	cursor: sw-resize;
 
-	float: left;
+	/* `liferay-r2` takes care of processing external/internal CSS resources
+	on DXP and already deals with converting float directions.
+	So, we will be forcing those styles to be right because `liferay-r2`
+	will take care of converting this direction to left */
+	float: right;
 	margin-left: -4px;
 	right: auto;
 }

--- a/skins/moono-lexicon/mainui.css
+++ b/skins/moono-lexicon/mainui.css
@@ -147,6 +147,9 @@ Special outer level classes used in this file:
 	/* 	A margin in case of no other element in the same container
 		to keep a distance to the bottom edge. */
 	margin-bottom: 2px;
+
+	float: right;
+	margin-right: -4px;
 }
 
 .cke_hc .cke_resizer {
@@ -158,9 +161,6 @@ Special outer level classes used in this file:
 
 .cke_resizer_ltr {
 	cursor: se-resize;
-
-	float: right;
-	margin-right: -4px;
 }
 
 /* This class is added in RTL mode. This is a special case for the resizer
@@ -168,19 +168,7 @@ Special outer level classes used in this file:
    RTL mode if the main UI is RTL. It depends instead on the context where the
    editor is inserted on. */
 .cke_resizer_rtl {
-	border-width: 10px 0 0 10px;
-	border-color: transparent transparent transparent #bcbcbc;
-	border-style: dashed dashed dashed solid;
-
 	cursor: sw-resize;
-
-	/* `liferay-r2` takes care of processing external/internal CSS resources
-	on DXP and already deals with converting float directions.
-	So, we will be forcing those styles to be right because `liferay-r2`
-	will take care of converting this direction to left */
-	float: right;
-	margin-left: -4px;
-	right: auto;
 }
 
 /* The editing area (where users type) can be rendered as an editable <div>


### PR DESCRIPTION
# How to reproduce this issue?

Open anywhere on DXP where the resize plugin was enabled. You could go to Web Content -> create new basic web content and take a look at the editor contained on the sidebar.

If you aren't viewing your DXP in Arabic, you'll see the drag handler of the resize is on the right side of the editor area. This is correct.

When enabling RTL, I mean enabling a language written from right to left, like Arab or Hebrew; you may see the drag handle still on the right side.

# Why? Findings

I noticed the styles on `moono-lexicon` that deals with RTL/LTR on `ckeditor` side are correct. If you take a look at [this page](https://ckeditor.com/ckeditor-4/demo/), you'll notice the class that is responsible for positioning the handler on the right side have the same name and the implementation as `moono-lexicon` but there is another class responsible for RTL styles that already does this job for us.

DXP Side:

`liferay-r2` takes care of processing external/internal CSS resources on DXP and already deals with converting float directions. 

I haven't found how to skip a determined CSS class on the build process since it's the recommended approach because I'm not sure if we should go with disabling all processing of ckeditor CSS at [this part](https://cs.github.com/liferay/liferay-portal/blob/ca8a5112e6253e866f35987b8362a9305e174b51/modules/build.gradle#L402). 

**So, we will be forcing those styles to be right because `liferay-r2` will take care of converting this direction to left.**


# Screenshots

## Before: 

<img src="https://user-images.githubusercontent.com/7663513/182483947-4695a89a-9f60-4f46-8378-15e3f33743af.png" alt="before" width="300" />

## After:

<img src="https://user-images.githubusercontent.com/7663513/182483879-2468d4d8-d412-4dee-a64a-8a47acbca4dc.png" alt="before" width="300" />


Link to the ticket: https://issues.liferay.com/browse/LPS-138145