### PR TITLE
fix: LPS-163662 CKEditor element flickering

### DIFF
--- a/skins/moono-lexicon/richcombo.css
+++ b/skins/moono-lexicon/richcombo.css
@@ -195,7 +195,7 @@ a.cke_combo_button {
 .cke_toolbar_break + .cke_toolbar > .cke_toolbar_start + .cke_combo_off a.cke_combo_button:active {
 	/* If first combo in a row do not use negative margin so it is aligned with other rows on hover. */
 	padding: 6px 18px;
-	margin: 0 4px 0 0;
+	margin: 0 4px 0 4px;
 }
 
 .cke_hc


### PR DESCRIPTION
[LPS-163662](https://issues.liferay.com/browse/LPS-163662) Added margin to stop CKEditor element flickering.

This change was added based on the conversation on [PTR-3391](https://issues.liferay.com/browse/PTR-3391).