### PR TITLE
fix: LPS-166086 Make dialog close button accessible with keyboard

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From e3d0dc6dea9b1a413f7c70ea5fd66e6c6d03e278 Mon Sep 17 00:00:00 2001
+From e76eab0b67fb05e447e27f4d91d29fb5e3b3e156 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From bc03b720b4431b11776cdf34d4a70922eb90a56a Mon Sep 17 00:00:00 2001
+From 69ebae7392c9b47f8466f9526db09273a3389386 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From 0f08683be8d31119ea25fb2a753f606379cddd6e Mon Sep 17 00:00:00 2001
+From 8c846c8235c72ef14e3d30263dff16afcc67aa8e Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From 1cdc7c74572905d5bc34834db30c0498680a8876 Mon Sep 17 00:00:00 2001
+From ae7db1ef7f96bd848dd02b8df8d1a9185d3402e1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 8b4da009a9cf77a7fdaa16e7e09b67f5640a52c3 Mon Sep 17 00:00:00 2001
+From 76c744e4e580bc7605e402482151ab8dd3d07cc4 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From 5b1a436e79956e1daaf572813457f619fed1ff9d Mon Sep 17 00:00:00 2001
+From 7ac8f4d5202a05b1fb2b294f4c49c14e9dc23235 Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From d97257b9502be696c0c94c36365188af28a6ed6d Mon Sep 17 00:00:00 2001
+From d6111b70b706abd74b368804c19e01bbd922c5c8 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From c71372d2ca8ca43beead269e4fb082d2cf8c27c5 Mon Sep 17 00:00:00 2001
+From 72bdfe676b276127aa8346973b9b8b7641ff32e7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,

--- a/patches/0009-LPS-131699-Add-null-check.patch
+++ b/patches/0009-LPS-131699-Add-null-check.patch
@@ -1,4 +1,4 @@
-From bf78419124fecbce9542c2ae7958a76879d0d977 Mon Sep 17 00:00:00 2001
+From 8aa5a090600908fd19cfc279f0866c8a3208ea25 Mon Sep 17 00:00:00 2001
 From: IstvanD <istvan.dezsi@liferay.com>
 Date: Wed, 19 May 2021 17:43:17 +0200
 Subject: [PATCH] LPS-131699 Add null check

--- a/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
+++ b/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
@@ -1,4 +1,4 @@
-From 01ba9f29c74507faf84c296ff1a5a0fffa6e050a Mon Sep 17 00:00:00 2001
+From 30f3d7da194b34352b450b303e8639a4ba1ba5ed Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 9 Aug 2021 18:04:44 +0200
 Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it

--- a/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
+++ b/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
@@ -1,4 +1,4 @@
-From fc9c9c728217db6fac6441596ec6224d485198cc Mon Sep 17 00:00:00 2001
+From 27c2730c6b690eaf73fc7e9fca705eee8dcf66d8 Mon Sep 17 00:00:00 2001
 From: Norbert Nemeth <norbert.nemeth@liferay.com>
 Date: Tue, 17 Aug 2021 11:20:58 +0200
 Subject: [PATCH] LPS-136998 Avoid breaking the UI in firefox

--- a/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
+++ b/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
@@ -1,4 +1,4 @@
-From 6c0dd7fa53a2fe934b723cc80ceea811c7fdf5c8 Mon Sep 17 00:00:00 2001
+From 11f50c18cd259ac2be6fb75bc5780d22f7e3f07c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 16 Aug 2021 18:36:20 +0200
 Subject: [PATCH] LPS-137425 Don't check selection on focus

--- a/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
+++ b/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
@@ -1,4 +1,4 @@
-From a343dfde2e895cba7c369f4c05ce5436ec6eb673 Mon Sep 17 00:00:00 2001
+From e0a2a4b63949e9de92bcb9c51188e5196a5dec70 Mon Sep 17 00:00:00 2001
 From: Minhchau <minhchau.dang@liferay.com>
 Date: Tue, 28 Sep 2021 11:18:40 -0700
 Subject: [PATCH] LPS-139565 When upgrading from 6.2 to 7.1, image width/height

--- a/patches/0014-LPS-137763-If-contentsElement-is-defined-use-it-as-a.patch
+++ b/patches/0014-LPS-137763-If-contentsElement-is-defined-use-it-as-a.patch
@@ -1,4 +1,4 @@
-From 89333501caea4ab6070c2eeb58de62ef13b27ce2 Mon Sep 17 00:00:00 2001
+From f6e9b7acb23f3a4fe3b13d05cb85f9c0c41132d3 Mon Sep 17 00:00:00 2001
 From: Diego Nascimento <diego.nascimento@liferay.com>
 Date: Mon, 18 Oct 2021 17:45:43 -0300
 Subject: [PATCH] LPS-137763 If contentsElement is defined, use it as a

--- a/patches/0015-LPS-166086-Make-dialog-close-button-accessible-with-.patch
+++ b/patches/0015-LPS-166086-Make-dialog-close-button-accessible-with-.patch
@@ -1,0 +1,37 @@
+From ea1d4e9c8daefb635c256e45d9747897a5c38b75 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
+Date: Fri, 21 Oct 2022 15:28:58 +0200
+Subject: [PATCH] LPS-166086 Make dialog close button accessible with keyboard
+
+---
+ plugins/dialog/plugin.js | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/plugins/dialog/plugin.js b/plugins/dialog/plugin.js
+index a1fdc81ff1..5d328a1675 100644
+--- a/plugins/dialog/plugin.js
++++ b/plugins/dialog/plugin.js
+@@ -160,7 +160,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
+ 				'<tr><td role="presentation">' +
+ 				'<div class="cke_dialog_body" role="presentation">' +
+ 					'<div id="cke_dialog_title_{id}" class="cke_dialog_title" role="presentation"></div>' +
+-					'<a id="cke_dialog_close_button_{id}" class="cke_dialog_close_button" href="javascript:void(0)" title="{closeTitle}" role="button"><span class="cke_label">X</span></a>' +
++					'<a id="cke_dialog_close_button_{id}" class="cke_dialog_close_button close" href="javascript:void(0)" title="{closeTitle}" role="button"><span class="cke_label">X</span></a>' +
+ 					'<div id="cke_dialog_tabs_{id}" class="cke_dialog_tabs" role="tablist"></div>' +
+ 					'<table class="cke_dialog_contents" role="presentation">' +
+ 					'<tr>' +
+@@ -425,9 +425,13 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
+ 		this.parts.close.on( 'click', function( evt ) {
+ 			if ( this.fire( 'cancel', { hide: true } ).hide !== false )
+ 				this.hide();
+-			evt.data.preventDefault();
++			evt.data && evt.data.preventDefault();
+ 		}, this );
+ 
++		this.on( 'load', function () {
++			this.addFocusable(this.parts.close);
++		});
++
+ 		// Sort focus list according to tab order definitions.
+ 		function setupFocus() {
+ 			var focusList = me._.focusList;


### PR DESCRIPTION
### References

- [LPS-166086 CKEditor modals cannot be closed by keyboard focusing "X" button](https://issues.liferay.com/browse/LPS-166086)

### What is the goal of this PR?

In the PR, we are:
- Adding close button to the list of focusable items in dialog.
- Fixing outline styles in DXP, by adding `close` CSS class.
- Fixing close event JS error when close is done over keyboard.

### What does it look like?

I wanted to add a gif here, but my recording software (peek on ubuntu) refused to record focus changes. Here is a screenshot:
 
![screen](https://user-images.githubusercontent.com/5435511/197222269-b6612232-61ef-4bd3-9e6d-39b0eed26e80.png)

### Steps to reproduce

See steps to reproduce in JIRA ticket.