### PR TITLE
fix: LPS-165655 use Esc key to blur from codemirror

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -22,6 +22,11 @@
 				codeMirrorInstance.codeMirrorEditor = CodeMirror.fromTextArea(
 					textarea.$,
 					{
+						extraKeys: {
+							Esc: function(cm) {
+								cm.display.input.blur();
+							}
+						},
 						lineNumbers: true,
 						lineWrapping: true,
 						mode: 'text/html',


### PR DESCRIPTION
In this PR we are allowing users to tab out the codemirror editor, which we use for the Source Mode. By default, this editor uses `Tab` key to indent content in the edition area, rather than swithcing focus.

We adopted the same solution [codemirror6 proposes in this example](https://codemirror.net/examples/tab/), this time, using our codemirror5 plugin.

With this change, when editor is in source mode, pressing `Esc` key would make editor to lose focus, therefore, `Tab` key becomes available again.

A followup PR should ensure this info is made available to the user