### PR TITLE
LPD-42473 Instead of setting a width from image2 plugin, we'll do it in portal

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From 90eb3eb89ace6852849757f62598b71069aa092b Mon Sep 17 00:00:00 2001
+From 29801c91f5ea023bd58be31d0f945c173dc3cb08 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 3f4732e13cb72e39c1fc59f8d20ad939f26e0165 Mon Sep 17 00:00:00 2001
+From 33495f0f79457ebee88786da204ea7d6ecddf049 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From 4656b7b8892006f671fd19f6354359ca31c58896 Mon Sep 17 00:00:00 2001
+From 1b4ab140d4eb817cf546cb6a7e5282c9bb2ce707 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From 0e8761981e8bf3e9010865d1fb3addba73e04487 Mon Sep 17 00:00:00 2001
+From f25aca5aeb3d33b4d5b5ca974b62317e00a921a9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From a185e634d66409c1ada93e162d70ed4f8f16c21e Mon Sep 17 00:00:00 2001
+From bc583a7b1c1ffee71a4f4392d2260692c676a61e Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From 5b6cb3bed40ee4441a5158f9097f3eaf89755851 Mon Sep 17 00:00:00 2001
+From 64ee4242c5d79bfb97323b1251ce4973f5c94f8f Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From 5ac4e880f10960cad9586cd1b7ba15dd16610b55 Mon Sep 17 00:00:00 2001
+From 279ad4f7b3adae0607522836d0318dc3084042fc Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From 07776debacb9e41c19042b6ce561d3d07af4dbdb Mon Sep 17 00:00:00 2001
+From 725eb0143a19f7ac5087432d4b59044a93a0236b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,

--- a/patches/0009-LPS-131699-Add-null-check.patch
+++ b/patches/0009-LPS-131699-Add-null-check.patch
@@ -1,4 +1,4 @@
-From 1206b0c5850379339fd711c03b4a2e4c39dc5d98 Mon Sep 17 00:00:00 2001
+From e0a825239a821890fa8ab8c6a50f8a35a0575760 Mon Sep 17 00:00:00 2001
 From: IstvanD <istvan.dezsi@liferay.com>
 Date: Wed, 19 May 2021 17:43:17 +0200
 Subject: [PATCH] LPS-131699 Add null check

--- a/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
+++ b/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
@@ -1,4 +1,4 @@
-From 473feb23167c20ab3fb075203d722f62233173f9 Mon Sep 17 00:00:00 2001
+From a91d39f273025584ab79b43e7876185f867a76e7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 9 Aug 2021 18:04:44 +0200
 Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it

--- a/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
+++ b/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
@@ -1,4 +1,4 @@
-From 704bdc19a547e51e39048d01605b4de287fc1bee Mon Sep 17 00:00:00 2001
+From e7f9449d2dce80ffcc0e204a562541313db23f49 Mon Sep 17 00:00:00 2001
 From: Norbert Nemeth <norbert.nemeth@liferay.com>
 Date: Tue, 17 Aug 2021 11:20:58 +0200
 Subject: [PATCH] LPS-136998 Avoid breaking the UI in firefox

--- a/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
+++ b/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
@@ -1,4 +1,4 @@
-From 8fe0fada44158ac1efc9d57473090d16c550b92a Mon Sep 17 00:00:00 2001
+From ac7cfb79fab9b33a029fb94d751c4c0e93539a0f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 16 Aug 2021 18:36:20 +0200
 Subject: [PATCH] LPS-137425 Don't check selection on focus

--- a/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
+++ b/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
@@ -1,4 +1,4 @@
-From 034db9674b2fbfc6428daf24a0af6f9414d6bde0 Mon Sep 17 00:00:00 2001
+From 7c8599b25b6e2aecbfa7e35e3eea54bef59f2e1c Mon Sep 17 00:00:00 2001
 From: Minhchau <minhchau.dang@liferay.com>
 Date: Tue, 28 Sep 2021 11:18:40 -0700
 Subject: [PATCH] LPS-139565 When upgrading from 6.2 to 7.1, image width/height

--- a/patches/0014-LPS-137763-If-contentsElement-is-defined-use-it-as-a.patch
+++ b/patches/0014-LPS-137763-If-contentsElement-is-defined-use-it-as-a.patch
@@ -1,4 +1,4 @@
-From 777eab6232780915f11f88fb7a72b0af164a0740 Mon Sep 17 00:00:00 2001
+From a7180dde47d98ab2706e0583639f25aa1dfdb6fa Mon Sep 17 00:00:00 2001
 From: Diego Nascimento <diego.nascimento@liferay.com>
 Date: Mon, 18 Oct 2021 17:45:43 -0300
 Subject: [PATCH] LPS-137763 If contentsElement is defined, use it as a

--- a/patches/0015-LPS-166086-Make-dialog-close-button-accessible-with-.patch
+++ b/patches/0015-LPS-166086-Make-dialog-close-button-accessible-with-.patch
@@ -1,4 +1,4 @@
-From 96394f2f45d49c631c7e965dc9a8e320b47f3c23 Mon Sep 17 00:00:00 2001
+From d260a8800444c90cde76bc02f9da45994eb3250e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Fri, 21 Oct 2022 15:28:58 +0200
 Subject: [PATCH] LPS-166086 Make dialog close button accessible with keyboard

--- a/patches/0016-LPD-19992-Validate-id-and-name-fields-according-to-s.patch
+++ b/patches/0016-LPD-19992-Validate-id-and-name-fields-according-to-s.patch
@@ -1,4 +1,4 @@
-From 385f30ad346b40b2f77048c566f04103b7a7e9f6 Mon Sep 17 00:00:00 2001
+From e11429a3ad09794491c5b8dd1037219f142111d3 Mon Sep 17 00:00:00 2001
 From: Antonio Ortega <60252917@liferay.com>
 Date: Fri, 15 Mar 2024 16:01:20 +0100
 Subject: [PATCH] LPD-19992 Validate id and name fields according to spec

--- a/patches/0017-LPD-20726-Always-set-some-width-to-img-container.patch
+++ b/patches/0017-LPD-20726-Always-set-some-width-to-img-container.patch
@@ -1,4 +1,4 @@
-From d22d33315222923743600754b5fa27757b698531 Mon Sep 17 00:00:00 2001
+From d5dc675f41a0b3609df60dd4bfd0ce1e4a58ee41 Mon Sep 17 00:00:00 2001
 From: Antonio Ortega <60252917@liferay.com>
 Date: Mon, 18 Mar 2024 15:20:47 +0100
 Subject: [PATCH] LPD-20726 Always set some width to img container

--- a/patches/0018-LPD-33712-Add-css-to-combopanel-when-maximized.patch
+++ b/patches/0018-LPD-33712-Add-css-to-combopanel-when-maximized.patch
@@ -1,4 +1,4 @@
-From 437893b2c0b26558e06037dd91053dcab52cb803 Mon Sep 17 00:00:00 2001
+From 7920704c27fa990464c5517bee90cc87a91a76de Mon Sep 17 00:00:00 2001
 From: Fortunato <fortunato.maldonado@liferay.com>
 Date: Thu, 22 Aug 2024 11:20:50 -0600
 Subject: [PATCH] LPD-33712 Add css to combopanel when maximized

--- a/patches/0019-LPD-35604-Add-title-to-iframe.patch
+++ b/patches/0019-LPD-35604-Add-title-to-iframe.patch
@@ -1,4 +1,4 @@
-From 5dee04eef1b409bbccfa6fb34acc9a764e5b146b Mon Sep 17 00:00:00 2001
+From c19d0eefaa6529bb10f3ed55040d388507028363 Mon Sep 17 00:00:00 2001
 From: Fortunato Maldonado <fortunato.maldonado@liferay.com>
 Date: Thu, 5 Sep 2024 11:28:29 -0600
 Subject: [PATCH] LPD-35604 Add title to iframe

--- a/patches/0020-LPD-42473-Set-a-width-based-on-px-so-it-does-not-aff.patch
+++ b/patches/0020-LPD-42473-Set-a-width-based-on-px-so-it-does-not-aff.patch
@@ -1,4 +1,4 @@
-From ad6fc1ee4d79e88a8edab5211a5f955a39d6dc45 Mon Sep 17 00:00:00 2001
+From e42c3300a2a5266989d1911a29c325d3aafbd915 Mon Sep 17 00:00:00 2001
 From: Antonio Ortega <60252917@liferay.com>
 Date: Wed, 20 Nov 2024 13:35:16 +0100
 Subject: [PATCH] LPD-42473 Set a width based on px so it does not affect image

--- a/patches/0021-LPD-42473-Instead-of-setting-a-width-from-image2-plu.patch
+++ b/patches/0021-LPD-42473-Instead-of-setting-a-width-from-image2-plu.patch
@@ -1,0 +1,25 @@
+From f49502373d3f8115adfe6184a921ca9a4b26ebe7 Mon Sep 17 00:00:00 2001
+From: Antonio Ortega <60252917@liferay.com>
+Date: Wed, 4 Dec 2024 14:09:03 +0100
+Subject: [PATCH] LPD-42473 Instead of setting a width from image2 plugin,
+ we'll do it directly inside portal when rendering the image
+
+---
+ plugins/image2/plugin.js | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/plugins/image2/plugin.js b/plugins/image2/plugin.js
+index da58812eff..bcf986bad4 100644
+--- a/plugins/image2/plugin.js
++++ b/plugins/image2/plugin.js
+@@ -376,8 +376,8 @@
+ 						hasCaption: !!this.parts.caption,
+ 						src: image.getAttribute( 'src' ),
+ 						alt: image.getAttribute( 'alt' ) || '',
+-						width: image.$.style.width && parseInt( image.$.style.width ) || image.getAttribute( 'width' ) || '150px',
+-						height: image.$.style.height && parseInt( image.$.style.height ) || image.getAttribute( 'height' ) || 'auto',
++						width: image.$.style.width && parseInt( image.$.style.width ) || image.getAttribute( 'width' ) || '',
++						height: image.$.style.height && parseInt( image.$.style.height ) || image.getAttribute( 'height' ) || '',
+ 
+ 						// Lock ratio should respect the value of the config.image2_defaultLockRatio.
+ 						// If the variable is not set, then it fallback to the legacy one


### PR DESCRIPTION
Hi,

This new patch (#21) is basically reverting our previous tries (#20, #17) to render images with no width. 

After a deeper analysis, we've seen none of these solutions is working 100% and this issue should be better handled inside Liferay Portal, to be more exact, within [itemselector](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js#L248-L288) plugin.

Once this pr gets merged, I'll release a new liferay-ckeditor version, and then I'll send a pull request to liferay-portal upgrade such version and including the fix within itemselector plugin.

Thanks.

Regards.