### PR TITLE
LPD-45919 Remove plugins/codesnippetgeshi so it is not shipped in our liferay-ckeditor

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -69,6 +69,9 @@ case "$COMMAND" in
 				rm -rf temp
 				cp -r ckeditor-dev temp
 
+				# Remove codesnippetgeshi plugin
+				rm -rf temp/plugins/codesnippetgeshi
+
 				# Copy custom skins
 				cp -r skins temp
 


### PR DESCRIPTION
[Previous pull requeest](https://github.com/liferay/liferay-ckeditor/pull/221)

As suggested [here](https://github.com/liferay/liferay-ckeditor/pull/221#discussion_r1923401242) rather than creating a huge patch, we can do the same just removing that directory when building liferay-ckeditor.