### PR TITLE
LPD-48102 Incorrect CDATA detection may cause security issue

### DIFF
--- a/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
+++ b/patches/0001-LPS-89596-Cannot-Drag-Image-from-top-content-line-in.patch
@@ -1,4 +1,4 @@
-From 5e42373fe6b3bd4a8a83f7e8c6f4dc2766b852ca Mon Sep 17 00:00:00 2001
+From 3399fda06f9c6533c29bcb9758b1b19286fbf847 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
 Subject: [PATCH] LPS-89596 Cannot Drag Image from top content line in IE11
@@ -10,7 +10,7 @@ Changed position of drag icon for IE.
  1 file changed, 4 insertions(+)
 
 diff --git a/plugins/widget/plugin.js b/plugins/widget/plugin.js
-index 54770a7dac..d462cfcdb0 100644
+index 54770a7..d462cfc 100644
 --- a/plugins/widget/plugin.js
 +++ b/plugins/widget/plugin.js
 @@ -1607,6 +1607,10 @@

--- a/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
+++ b/patches/0002-LPS-95472-Tabs-in-popups-not-appears-correctly-in-ma.patch
@@ -1,4 +1,4 @@
-From 5fc8727de4fdc59385ddf17b2c35d7a138a13fa4 Mon Sep 17 00:00:00 2001
+From 0f343bf1b312b987c6c510b49db82827ffa8473c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 21 May 2019 09:38:15 +0200
 Subject: [PATCH] LPS-95472 Tabs in popups not appears correctly in maximized
@@ -11,7 +11,7 @@ plugin.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/plugins/dialog/plugin.js b/plugins/dialog/plugin.js
-index b6a5077918..5101c888ff 100644
+index b6a5077..5101c88 100644
 --- a/plugins/dialog/plugin.js
 +++ b/plugins/dialog/plugin.js
 @@ -1188,7 +1188,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;

--- a/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
+++ b/patches/0003-LPS-85326-Remove-check-for-Webkit-browsers.patch
@@ -1,4 +1,4 @@
-From 110d377bdb07e5a2ea0d91e29d3f4f12c57a43e3 Mon Sep 17 00:00:00 2001
+From ba4330c9c6f4ade5eb65cda9608b573ad4669032 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Wed, 25 Mar 2020 12:58:15 +0100
 Subject: [PATCH] LPS-85326 Remove check for Webkit browsers
@@ -18,7 +18,7 @@ https://github.com/liferay/liferay-ckeditor/commit/328017c65063ac18119e244fec92d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/selection.js b/core/selection.js
-index 48d5732f76..854796a3bd 100644
+index 48d5732..854796a 100644
 --- a/core/selection.js
 +++ b/core/selection.js
 @@ -2280,7 +2280,7 @@

--- a/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
+++ b/patches/0004-LPP-36989-Remove-obsolete-summary-field-from-table-e.patch
@@ -1,4 +1,4 @@
-From bb39f862ac062264ea232b69262d32ad6e6b6da8 Mon Sep 17 00:00:00 2001
+From a0dce03dbb413cbdef21fb3a6ae9b3476aa94d4f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Tue, 14 Apr 2020 10:15:56 +0200
 Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements
@@ -15,7 +15,7 @@ Subject: [PATCH] LPP-36989 Remove obsolete summary field from table elements
  8 files changed, 38 insertions(+), 56 deletions(-)
 
 diff --git a/plugins/table/dialogs/table.js b/plugins/table/dialogs/table.js
-index acc0210f6d..64101f74f2 100755
+index acc0210..64101f7 100755
 --- a/plugins/table/dialogs/table.js
 +++ b/plugins/table/dialogs/table.js
 @@ -538,22 +538,6 @@
@@ -42,7 +42,7 @@ index acc0210f6d..64101f74f2 100755
  				} ]
  			},
 diff --git a/plugins/table/plugin.js b/plugins/table/plugin.js
-index 69efd521a1..9d1c144648 100755
+index 69efd52..9d1c144 100755
 --- a/plugins/table/plugin.js
 +++ b/plugins/table/plugin.js
 @@ -18,7 +18,7 @@ CKEDITOR.plugins.add( 'table', {
@@ -55,7 +55,7 @@ index 69efd521a1..9d1c144648 100755
  				'th td tr[scope];' +
  				'td{border*,background-color,vertical-align,width,height}[colspan,rowspan];' +
 diff --git a/tests/plugins/table/table.html b/tests/plugins/table/table.html
-index e6766708df..6b97e0c699 100644
+index e676670..6b97e0c 100644
 --- a/tests/plugins/table/table.html
 +++ b/tests/plugins/table/table.html
 @@ -37,7 +37,7 @@
@@ -68,7 +68,7 @@ index e6766708df..6b97e0c699 100644
  	<thead>
  	<tr>
 diff --git a/tests/plugins/table/table.js b/tests/plugins/table/table.js
-index 6e1cc30614..104de739c2 100644
+index 6e1cc30..104de73 100644
 --- a/tests/plugins/table/table.js
 +++ b/tests/plugins/table/table.js
 @@ -80,16 +80,14 @@
@@ -91,7 +91,7 @@ index 6e1cc30614..104de739c2 100644
  					dialog.fire( 'ok' );
  					dialog.hide();
 diff --git a/tests/plugins/tableselection/integrations/tabletools/tabletools.html b/tests/plugins/tableselection/integrations/tabletools/tabletools.html
-index a9df442abb..eccbbafa70 100644
+index a9df442..eccbbaf 100644
 --- a/tests/plugins/tableselection/integrations/tabletools/tabletools.html
 +++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.html
 @@ -1,5 +1,5 @@
@@ -237,7 +237,7 @@ index a9df442abb..eccbbafa70 100644
  	<tr>
  		<td>cell1</td>
 diff --git a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
-index da23513f94..7abd4bcdfb 100644
+index da23513..7abd4bc 100644
 --- a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
 +++ b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
 @@ -1,5 +1,5 @@
@@ -248,7 +248,7 @@ index da23513f94..7abd4bcdfb 100644
  		<tr>
  			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
 diff --git a/tests/plugins/tabletools/manual/columndeletionerror.html b/tests/plugins/tabletools/manual/columndeletionerror.html
-index b3cc3d03b5..f84850c69a 100644
+index b3cc3d0..f84850c 100644
 --- a/tests/plugins/tabletools/manual/columndeletionerror.html
 +++ b/tests/plugins/tabletools/manual/columndeletionerror.html
 @@ -1,5 +1,5 @@
@@ -259,7 +259,7 @@ index b3cc3d03b5..f84850c69a 100644
  		<tr>
  			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
 diff --git a/tests/plugins/tabletools/tabletools.html b/tests/plugins/tabletools/tabletools.html
-index e9f45e5921..70d2f07980 100644
+index e9f45e5..70d2f07 100644
 --- a/tests/plugins/tabletools/tabletools.html
 +++ b/tests/plugins/tabletools/tabletools.html
 @@ -1,5 +1,5 @@

--- a/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
+++ b/patches/0005-LPS-112982-Add-additional-resource-URL-parameters.patch
@@ -1,4 +1,4 @@
-From 9e3f0b69f0849b17643bafaaef900f4f9a4deb60 Mon Sep 17 00:00:00 2001
+From abb9420425e88efb5af074e2bf6c54e4d3cacfb4 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 7 Jul 2020 09:47:27 +0200
 Subject: [PATCH] LPS-112982 Add additional resource URL parameters
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-112982 Add additional resource URL parameters
  2 files changed, 27 insertions(+), 5 deletions(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index 3fe1158f93..b68e88d5c2 100644
+index 3fe1158..b68e88d 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -175,13 +175,26 @@ if ( !window.CKEDITOR ) {
@@ -45,7 +45,7 @@ index 3fe1158f93..b68e88d5c2 100644
  
  			/**
 diff --git a/core/config.js b/core/config.js
-index 73db6e7e19..7660ed527f 100644
+index 73db6e7..7660ed5 100644
 --- a/core/config.js
 +++ b/core/config.js
 @@ -8,6 +8,15 @@

--- a/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
+++ b/patches/0006-LPS-118624-Don-t-pass-languageId-to-css-files-reques.patch
@@ -1,4 +1,4 @@
-From 050406f72df9c0e09927b84fe1a10881d70119d5 Mon Sep 17 00:00:00 2001
+From 2f1555069cfcc200ef3ec1eb4f86580d83df0c76 Mon Sep 17 00:00:00 2001
 From: Carlos Lancha <carlos.lancha@liferay.com>
 Date: Thu, 6 Aug 2020 14:42:21 +0200
 Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-118624 Don't pass languageId to css files requests
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index b68e88d5c2..de87cd6d52 100644
+index b68e88d..de87cd6 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -188,7 +188,7 @@ if ( !window.CKEDITOR ) {

--- a/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
+++ b/patches/0007-LPS-124728-Avoid-breaking-IE11.patch
@@ -1,4 +1,4 @@
-From 59dc5797ed2595d017d70098875e2fdde5de53ce Mon Sep 17 00:00:00 2001
+From 6e079636f8b0cbc0dfd3a69457b8c791d80c71f4 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Mon, 21 Dec 2020 09:12:53 +0100
 Subject: [PATCH] LPS-124728 Avoid breaking IE11
@@ -11,7 +11,7 @@ they aren't loaded when getUrl is executed.
  1 file changed, 18 insertions(+), 12 deletions(-)
 
 diff --git a/core/ckeditor_base.js b/core/ckeditor_base.js
-index de87cd6d52..7e8120b797 100644
+index de87cd6..7e8120b 100644
 --- a/core/ckeditor_base.js
 +++ b/core/ckeditor_base.js
 @@ -175,26 +175,32 @@ if ( !window.CKEDITOR ) {

--- a/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
+++ b/patches/0008-LPS-125559-Fix-width-for-the-following-fields-Cell-s.patch
@@ -1,4 +1,4 @@
-From f8b5aeba4a1c332684212b46ad0d546d2f0bbad3 Mon Sep 17 00:00:00 2001
+From 73e3c1f27e61ea5d5656a433b1b7bde91cd9f2bb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
 Date: Fri, 8 Jan 2021 10:58:23 +0100
 Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-125559 Fix width for the following fields Cell spacing,
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/plugins/table/dialogs/table.js b/plugins/table/dialogs/table.js
-index 64101f74f2..ae4a204123 100755
+index 64101f7..ae4a204 100755
 --- a/plugins/table/dialogs/table.js
 +++ b/plugins/table/dialogs/table.js
 @@ -357,7 +357,7 @@

--- a/patches/0009-LPS-131699-Add-null-check.patch
+++ b/patches/0009-LPS-131699-Add-null-check.patch
@@ -1,4 +1,4 @@
-From 844135dfd11d2d147f5584d941d820d33800986a Mon Sep 17 00:00:00 2001
+From 14880ad52d430eff940c201d0c4eb4e8e3604633 Mon Sep 17 00:00:00 2001
 From: IstvanD <istvan.dezsi@liferay.com>
 Date: Wed, 19 May 2021 17:43:17 +0200
 Subject: [PATCH] LPS-131699 Add null check
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-131699 Add null check
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/core/event.js b/core/event.js
-index 6dc8448f62..23c4919d15 100644
+index 6dc8448..23c4919 100644
 --- a/core/event.js
 +++ b/core/event.js
 @@ -172,7 +172,9 @@

--- a/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
+++ b/patches/0010-LPS-136119-Set-id-on-first-render-instead-of-changin.patch
@@ -1,4 +1,4 @@
-From 4d6be48d3c0fdf654266dbe686a4faab1045f7bd Mon Sep 17 00:00:00 2001
+From b179ba1a970346ea572daba6badd4a295492d5b1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 9 Aug 2021 18:04:44 +0200
 Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it
@@ -9,7 +9,7 @@ Subject: [PATCH] LPS-136119 Set `id` on first render, instead of changing it
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/plugins/button/plugin.js b/plugins/button/plugin.js
-index 19ece8424b..002302def8 100644
+index 19ece84..002302d 100644
 --- a/plugins/button/plugin.js
 +++ b/plugins/button/plugin.js
 @@ -146,7 +146,6 @@

--- a/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
+++ b/patches/0011-LPS-136998-Avoid-breaking-the-UI-in-firefox.patch
@@ -1,4 +1,4 @@
-From f9776b6c55295fbc680aa13b320c160b09b6d06e Mon Sep 17 00:00:00 2001
+From 9cb20860d02d4a243be5eccbbfebf48dbd867ff3 Mon Sep 17 00:00:00 2001
 From: Norbert Nemeth <norbert.nemeth@liferay.com>
 Date: Tue, 17 Aug 2021 11:20:58 +0200
 Subject: [PATCH] LPS-136998 Avoid breaking the UI in firefox
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-136998 Avoid breaking the UI in firefox
  1 file changed, 13 deletions(-)
 
 diff --git a/plugins/maximize/plugin.js b/plugins/maximize/plugin.js
-index a3625a1b31..85bc421f18 100644
+index a3625a1..85bc421 100644
 --- a/plugins/maximize/plugin.js
 +++ b/plugins/maximize/plugin.js
 @@ -72,19 +72,6 @@

--- a/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
+++ b/patches/0012-LPS-137425-Don-t-check-selection-on-focus.patch
@@ -1,4 +1,4 @@
-From d2116a597ce1517a7edf3dfa6bd374c72fe95ac4 Mon Sep 17 00:00:00 2001
+From bc8538ca37a55bead0460645b2641c0901819613 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 16 Aug 2021 18:36:20 +0200
 Subject: [PATCH] LPS-137425 Don't check selection on focus
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-137425 Don't check selection on focus
  1 file changed, 9 deletions(-)
 
 diff --git a/core/selection.js b/core/selection.js
-index 854796a3bd..65b221b6fc 100644
+index 854796a..65b221b 100644
 --- a/core/selection.js
 +++ b/core/selection.js
 @@ -977,15 +977,6 @@

--- a/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
+++ b/patches/0013-LPS-139565-When-upgrading-from-6.2-to-7.1-image-widt.patch
@@ -1,4 +1,4 @@
-From 47b3bfe03d9ba00e6c47881510b2c1b50d17267d Mon Sep 17 00:00:00 2001
+From 8c597f0db6fb7cff2a500a474eeeed85a4216bd8 Mon Sep 17 00:00:00 2001
 From: Minhchau <minhchau.dang@liferay.com>
 Date: Tue, 28 Sep 2021 11:18:40 -0700
 Subject: [PATCH] LPS-139565 When upgrading from 6.2 to 7.1, image width/height
@@ -10,7 +10,7 @@ If inline styles for height/width are set on the image, prefer those over the na
  1 file changed, 14 insertions(+), 2 deletions(-)
 
 diff --git a/plugins/image2/plugin.js b/plugins/image2/plugin.js
-index 63de6333e5..bcf986bad4 100644
+index 63de633..bcf986b 100644
 --- a/plugins/image2/plugin.js
 +++ b/plugins/image2/plugin.js
 @@ -376,8 +376,8 @@

--- a/patches/0014-LPS-137763-If-contentsElement-is-defined-use-it-as-a.patch
+++ b/patches/0014-LPS-137763-If-contentsElement-is-defined-use-it-as-a.patch
@@ -1,4 +1,4 @@
-From ee77bd1ebea2cac848594697193aed7aa727424c Mon Sep 17 00:00:00 2001
+From a060e0374e42c5f43be7898654c47fed57411c19 Mon Sep 17 00:00:00 2001
 From: Diego Nascimento <diego.nascimento@liferay.com>
 Date: Mon, 18 Oct 2021 17:45:43 -0300
 Subject: [PATCH] LPS-137763 If contentsElement is defined, use it as a
@@ -10,7 +10,7 @@ Subject: [PATCH] LPS-137763 If contentsElement is defined, use it as a
  2 files changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/core/creators/themedui.js b/core/creators/themedui.js
-index 7f8d56b30d..0c583a550b 100644
+index 7f8d56b..0c583a5 100644
 --- a/core/creators/themedui.js
 +++ b/core/creators/themedui.js
 @@ -267,8 +267,10 @@ CKEDITOR.replaceClass = 'ckeditor';
@@ -27,7 +27,7 @@ index 7f8d56b30d..0c583a550b 100644
  			editor.mode = '';
  		} else {
 diff --git a/plugins/wysiwygarea/plugin.js b/plugins/wysiwygarea/plugin.js
-index 4466b281d5..bdfe2ff6fe 100644
+index 4466b28..bdfe2ff 100644
 --- a/plugins/wysiwygarea/plugin.js
 +++ b/plugins/wysiwygarea/plugin.js
 @@ -42,7 +42,7 @@

--- a/patches/0015-LPS-166086-Make-dialog-close-button-accessible-with-.patch
+++ b/patches/0015-LPS-166086-Make-dialog-close-button-accessible-with-.patch
@@ -1,4 +1,4 @@
-From b2778bf57083404262849c479e520d81e0d155d3 Mon Sep 17 00:00:00 2001
+From 441550910047b215c0702f4b75dee6f0667829bd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Fri, 21 Oct 2022 15:28:58 +0200
 Subject: [PATCH] LPS-166086 Make dialog close button accessible with keyboard
@@ -8,7 +8,7 @@ Subject: [PATCH] LPS-166086 Make dialog close button accessible with keyboard
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/plugins/dialog/plugin.js b/plugins/dialog/plugin.js
-index 5101c888ff..6a38bef707 100644
+index 5101c88..6a38bef 100644
 --- a/plugins/dialog/plugin.js
 +++ b/plugins/dialog/plugin.js
 @@ -160,7 +160,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;

--- a/patches/0016-LPD-19992-Validate-id-and-name-fields-according-to-s.patch
+++ b/patches/0016-LPD-19992-Validate-id-and-name-fields-according-to-s.patch
@@ -1,4 +1,4 @@
-From cbfe73aec9799cb090f964bd73c7ba3b4825d7bf Mon Sep 17 00:00:00 2001
+From 6cbf256967e99c5e49942e2c9b4ddba2f0f2252d Mon Sep 17 00:00:00 2001
 From: Antonio Ortega <60252917@liferay.com>
 Date: Fri, 15 Mar 2024 16:01:20 +0100
 Subject: [PATCH] LPD-19992 Validate id and name fields according to spec
@@ -8,7 +8,7 @@ Subject: [PATCH] LPD-19992 Validate id and name fields according to spec
  1 file changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/plugins/link/dialogs/link.js b/plugins/link/dialogs/link.js
-index 46e452e741..39932fd2d9 100755
+index 46e452e..39932fd 100755
 --- a/plugins/link/dialogs/link.js
 +++ b/plugins/link/dialogs/link.js
 @@ -1010,7 +1010,18 @@

--- a/patches/0017-LPD-20726-Always-set-some-width-to-img-container.patch
+++ b/patches/0017-LPD-20726-Always-set-some-width-to-img-container.patch
@@ -1,4 +1,4 @@
-From 4009a7c64588850071354f9a4eca1242ad09df40 Mon Sep 17 00:00:00 2001
+From b0cca45956251098fa3c68b1163b7d84d6441a83 Mon Sep 17 00:00:00 2001
 From: Antonio Ortega <60252917@liferay.com>
 Date: Mon, 18 Mar 2024 15:20:47 +0100
 Subject: [PATCH] LPD-20726 Always set some width to img container
@@ -8,7 +8,7 @@ Subject: [PATCH] LPD-20726 Always set some width to img container
  1 file changed, 1 insertion(+)
 
 diff --git a/plugins/image2/plugin.js b/plugins/image2/plugin.js
-index bcf986bad4..c41fdad41c 100644
+index bcf986b..c41fdad 100644
 --- a/plugins/image2/plugin.js
 +++ b/plugins/image2/plugin.js
 @@ -31,6 +31,7 @@

--- a/patches/0018-LPD-33712-Add-css-to-combopanel-when-maximized.patch
+++ b/patches/0018-LPD-33712-Add-css-to-combopanel-when-maximized.patch
@@ -1,4 +1,4 @@
-From 3ef52bb155d4da309382c64954822bd2f1556343 Mon Sep 17 00:00:00 2001
+From 9ce92f9258b676d817b68d8ba38cb5d8f733baa4 Mon Sep 17 00:00:00 2001
 From: Fortunato <fortunato.maldonado@liferay.com>
 Date: Thu, 22 Aug 2024 11:20:50 -0600
 Subject: [PATCH] LPD-33712 Add css to combopanel when maximized
@@ -8,7 +8,7 @@ Subject: [PATCH] LPD-33712 Add css to combopanel when maximized
  1 file changed, 10 insertions(+)
 
 diff --git a/plugins/stylescombo/plugin.js b/plugins/stylescombo/plugin.js
-index 8b2b24d681..21840d5d60 100644
+index 8b2b24d..21840d5 100644
 --- a/plugins/stylescombo/plugin.js
 +++ b/plugins/stylescombo/plugin.js
 @@ -184,6 +184,16 @@

--- a/patches/0019-LPD-35604-Add-title-to-iframe.patch
+++ b/patches/0019-LPD-35604-Add-title-to-iframe.patch
@@ -1,4 +1,4 @@
-From fa1bd29cd5780b0726675cdf8c3f7736ed64e6ac Mon Sep 17 00:00:00 2001
+From 1ae64a7e49b65c324e8ef72950348883801fec6d Mon Sep 17 00:00:00 2001
 From: Fortunato Maldonado <fortunato.maldonado@liferay.com>
 Date: Thu, 5 Sep 2024 11:28:29 -0600
 Subject: [PATCH] LPD-35604 Add title to iframe
@@ -8,7 +8,7 @@ Subject: [PATCH] LPD-35604 Add title to iframe
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/plugins/wysiwygarea/plugin.js b/plugins/wysiwygarea/plugin.js
-index bdfe2ff6fe..97c849a80c 100644
+index bdfe2ff..97c849a 100644
 --- a/plugins/wysiwygarea/plugin.js
 +++ b/plugins/wysiwygarea/plugin.js
 @@ -38,7 +38,7 @@

--- a/patches/0020-LPD-42473-Set-a-width-based-on-px-so-it-does-not-aff.patch
+++ b/patches/0020-LPD-42473-Set-a-width-based-on-px-so-it-does-not-aff.patch
@@ -1,4 +1,4 @@
-From 3cfc9159b51480898e872e9c8b6aa00236d2a948 Mon Sep 17 00:00:00 2001
+From 04b6fcbee23090e2e84ddc58e2655002d476e4f5 Mon Sep 17 00:00:00 2001
 From: Antonio Ortega <60252917@liferay.com>
 Date: Wed, 20 Nov 2024 13:35:16 +0100
 Subject: [PATCH] LPD-42473 Set a width based on px so it does not affect image
@@ -9,7 +9,7 @@ Subject: [PATCH] LPD-42473 Set a width based on px so it does not affect image
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/plugins/image2/plugin.js b/plugins/image2/plugin.js
-index c41fdad41c..da58812eff 100644
+index c41fdad..da58812 100644
 --- a/plugins/image2/plugin.js
 +++ b/plugins/image2/plugin.js
 @@ -31,7 +31,6 @@

--- a/patches/0021-LPD-42473-Instead-of-setting-a-width-from-image2-plu.patch
+++ b/patches/0021-LPD-42473-Instead-of-setting-a-width-from-image2-plu.patch
@@ -1,4 +1,4 @@
-From 026f6a8977a90302beed86d7a36a6b0c31084009 Mon Sep 17 00:00:00 2001
+From f3e4668095183787444d23f2d0e1c3d3cfa33b67 Mon Sep 17 00:00:00 2001
 From: Antonio Ortega <60252917@liferay.com>
 Date: Wed, 4 Dec 2024 14:09:03 +0100
 Subject: [PATCH] LPD-42473 Instead of setting a width from image2 plugin,
@@ -9,7 +9,7 @@ Subject: [PATCH] LPD-42473 Instead of setting a width from image2 plugin,
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/plugins/image2/plugin.js b/plugins/image2/plugin.js
-index da58812eff..bcf986bad4 100644
+index da58812..bcf986b 100644
 --- a/plugins/image2/plugin.js
 +++ b/plugins/image2/plugin.js
 @@ -376,8 +376,8 @@

--- a/patches/0022-LPD-45795-Check-element-exists.patch
+++ b/patches/0022-LPD-45795-Check-element-exists.patch
@@ -1,4 +1,4 @@
-From 2d63d0d2ca9146f2b7e0a7413a605f12063ba5d9 Mon Sep 17 00:00:00 2001
+From 466a2e9351639fa1f241335b805609e7093ff24a Mon Sep 17 00:00:00 2001
 From: fortunato <fortunato.maldonado@liferay.com>
 Date: Fri, 10 Jan 2025 12:22:30 -0700
 Subject: [PATCH] LPD-45795 Check element exists
@@ -8,7 +8,7 @@ Subject: [PATCH] LPD-45795 Check element exists
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/plugins/widget/plugin.js b/plugins/widget/plugin.js
-index d462cfcdb0..16b71500dc 100644
+index d462cfc..16b7150 100644
 --- a/plugins/widget/plugin.js
 +++ b/plugins/widget/plugin.js
 @@ -522,7 +522,7 @@

--- a/patches/0023-LPD-45919-Exclude-samples-from-build.patch
+++ b/patches/0023-LPD-45919-Exclude-samples-from-build.patch
@@ -1,4 +1,4 @@
-From 4fd3f7d68944c2c59a14d9bd1c9e23c3971d5dcf Mon Sep 17 00:00:00 2001
+From 06274a54110984e97f905a478792931c0b7bf6eb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20=C4=8Ciko=C5=A1?= <marko.cikos@liferay.com>
 Date: Mon, 13 Jan 2025 17:19:15 +0100
 Subject: [PATCH] LPD-45919 Exclude samples from build
@@ -8,7 +8,7 @@ Subject: [PATCH] LPD-45919 Exclude samples from build
  1 file changed, 1 insertion(+)
 
 diff --git a/dev/builder/build-config.js b/dev/builder/build-config.js
-index edf0f865c2..10193cdcec 100644
+index edf0f86..10193cd 100644
 --- a/dev/builder/build-config.js
 +++ b/dev/builder/build-config.js
 @@ -32,6 +32,7 @@ var CKBUILDER_CONFIG = {

--- a/patches/0024-LPD-48102-Incorrect-CDATA-detection-may-cause-securi.patch
+++ b/patches/0024-LPD-48102-Incorrect-CDATA-detection-may-cause-securi.patch
@@ -1,0 +1,80 @@
+From 643bae1016f36458d5b1b9ecdf7a3f2ec61c02a5 Mon Sep 17 00:00:00 2001
+From: antonio-ortega <antonio.ortega@liferay.com>
+Date: Fri, 7 Feb 2025 15:06:31 +0100
+Subject: [PATCH] LPD-48102 Incorrect CDATA detection may cause security issue
+
+---
+ core/htmlparser.js | 32 +++++++++++++++++---------------
+ 1 file changed, 17 insertions(+), 15 deletions(-)
+
+diff --git a/core/htmlparser.js b/core/htmlparser.js
+index a7465bc..41fb71c 100644
+--- a/core/htmlparser.js
++++ b/core/htmlparser.js
+@@ -121,10 +121,7 @@ CKEDITOR.htmlParser = function() {
+ 				if ( tagIndex > nextIndex ) {
+ 					var text = html.substring( nextIndex, tagIndex );
+ 
+-					if ( cdata )
+-						cdata.push( text );
+-					else
+-						this.onText( text );
++					this.onText( text );
+ 				}
+ 
+ 				nextIndex = this._.htmlPartsRegex.lastIndex;
+@@ -142,7 +139,7 @@ CKEDITOR.htmlParser = function() {
+ 
+ 					if ( cdata && CKEDITOR.dtd.$cdata[ tagName ] ) {
+ 						// Send the CDATA data.
+-						this.onCDATA( cdata.join( '' ) );
++						this.onCDATA( cdata );
+ 						cdata = null;
+ 					}
+ 
+@@ -152,20 +149,15 @@ CKEDITOR.htmlParser = function() {
+ 					}
+ 				}
+ 
+-				// If CDATA is enabled, just save the raw match.
+-				if ( cdata ) {
+-					cdata.push( parts[ 0 ] );
+-					continue;
+-				}
+-
+ 				// Opening tag
+ 				if ( ( tagName = parts[ 3 ] ) ) {
+ 					tagName = tagName.toLowerCase();
+ 
+ 					// There are some tag names that can break things, so let's
+ 					// simply ignore them when parsing. (https://dev.ckeditor.com/ticket/5224)
+-					if ( /="/.test( tagName ) )
++					if ( /="/.test( tagName ) ) {
+ 						continue;
++					}
+ 
+ 					var attribs = {},
+ 						attribMatch,
+@@ -186,9 +178,19 @@ CKEDITOR.htmlParser = function() {
+ 
+ 					this.onTagOpen( tagName, attribs, selfClosing );
+ 
+-					// Open CDATA mode when finding the appropriate tags.
+-					if ( !cdata && CKEDITOR.dtd.$cdata[ tagName ] )
+-						cdata = [];
++					// CDATA
++					if ( CKEDITOR.dtd.$cdata[ tagName ] ) {
++						var closingTagRegex = new RegExp( '<\/' + tagName + '>', 'i' ),
++							htmlPart = html.substring( nextIndex ),
++							closingTagIndex = htmlPart.search( closingTagRegex );
++						// If closing tag was not found, treat all remaining text as CDATA.
++						if ( closingTagIndex === -1 ) {
++							closingTagIndex = htmlPart.length;
++						}
++						cdata = htmlPart.substring( 0, closingTagIndex );
++						this._.htmlPartsRegex.lastIndex = nextIndex + cdata.length;
++						nextIndex = this._.htmlPartsRegex.lastIndex;
++					}
+ 
+ 					continue;
+ 				}


### PR DESCRIPTION
Hi,

This is adressing: https://security.snyk.io/vuln/SNYK-JS-CKEDITOR4-6231771 ([CVE-2024-24815](https://www.cve.org/CVERecord?id=CVE-2024-24815)).

Previously,  in [LPD-2161](https://liferay.atlassian.net/browse/LPD-2161#icft=LPD-2161) we implemented content filtering in the rich text field. In addition, our ootb configs don't allow CDATA sections, so DXP is not vulnerable. Still, a particularly customized editor instance in a third party development could create the conditions for this one to be exploited. This commit is fixing that option following the same approach CKEditor did [here](https://github.com/ckeditor/ckeditor4/commit/8ed1a3c93d0ae5f49f4ecff5738ab8a2972194cb#diff-6c6037e4d615189525a9703677776380a85a114516446b672d7e26de4b2a118c).

Thanks.

Regards.